### PR TITLE
feat: 소모임 자동 입장 기능 구현 및 인원 제한 제거

### DIFF
--- a/src/main/java/com/helpie/backend/domain/group/Group.java
+++ b/src/main/java/com/helpie/backend/domain/group/Group.java
@@ -20,7 +20,7 @@ import java.util.Set;
  * 나라와 관심사를 기반으로 매칭된 소모임 (정원 5명)
  *
  * @author 전우선
- * @since 2025-10-25(토)
+ * @since 2025-10-30(목)
  */
 @Entity
 @Table(name = "user_groups")
@@ -111,14 +111,7 @@ public class Group {
      * 소모임에 멤버를 추가합니다.
      */
     public boolean addMember(Long userId) {
-        if (this.currentMembers >= this.maxMembers) {
-            return false;
-        }
-
         this.currentMembers++;
-        if (this.currentMembers >= this.maxMembers) {
-            this.status = GroupStatus.FULL;
-        }
         this.updatedAt = LocalDateTime.now();
         return true;
     }
@@ -128,17 +121,14 @@ public class Group {
      */
     public void removeMember(Long userId) {
         this.currentMembers--;
-        if (this.currentMembers < this.maxMembers && this.status == GroupStatus.FULL) {
-            this.status = GroupStatus.ACTIVE;
-        }
         this.updatedAt = LocalDateTime.now();
     }
 
     /**
-     * 소모임이 가득 찼는지 확인합니다.
+     * 소모임이 가득 찼는지 확인합니다. (현재는 무제한이므로 항상 false)
      */
     public boolean isFull() {
-        return this.currentMembers >= this.maxMembers;
+        return false;
     }
 
     /**

--- a/src/main/java/com/helpie/backend/service/chatroom/ChatRoomService.java
+++ b/src/main/java/com/helpie/backend/service/chatroom/ChatRoomService.java
@@ -1,5 +1,6 @@
 package com.helpie.backend.service.chatroom;
 
+import com.helpie.backend.domain.group.Group;
 import com.helpie.backend.dto.chatroom.ChatRoomResponse;
 import com.helpie.backend.dto.chatroom.ChatMessageResponse;
 import com.helpie.backend.dto.chatroom.SendMessageRequest;
@@ -12,7 +13,7 @@ import java.util.List;
  * 채팅방 서비스 인터페이스
  * 
  * @author 전우선
- * @since 2025-10-25(토)
+ * @since 2025-10-30(목)
  */
 public interface ChatRoomService {
     
@@ -70,4 +71,25 @@ public interface ChatRoomService {
      * @return 전송된 메시지 정보
      */
     ChatMessageResponse sendMessage(Long chatRoomId, SendMessageRequest request);
+    
+    /**
+     * 소모임에 대한 채팅방을 생성하고 사용자를 자동 입장시킵니다.
+     * 
+     * @param group 소모임
+     * @param userId 사용자 ID
+     * @param userName 사용자 이름
+     * @param welcomeMessage 환영 메시지
+     * @return 생성된 채팅방 ID
+     */
+    Long createChatRoomAndJoin(Group group, Long userId, String userName, String welcomeMessage);
+    
+    /**
+     * 사용자를 소모임 채팅방에 자동 입장시킵니다.
+     * 
+     * @param groupId 소모임 ID
+     * @param userId 사용자 ID
+     * @param userName 사용자 이름
+     * @param joinMessage 가입 메시지
+     */
+    void autoJoinGroupChatRoom(Long groupId, Long userId, String userName, String joinMessage);
 }

--- a/src/main/java/com/helpie/backend/service/chatroom/ChatRoomServiceImpl.java
+++ b/src/main/java/com/helpie/backend/service/chatroom/ChatRoomServiceImpl.java
@@ -4,6 +4,7 @@ import com.helpie.backend.domain.chatroom.ChatRoom;
 import com.helpie.backend.domain.chatroom.ChatRoomParticipant;
 import com.helpie.backend.domain.chatroom.ChatMessage;
 import com.helpie.backend.domain.chatroom.MessageType;
+import com.helpie.backend.domain.group.Group;
 import com.helpie.backend.domain.group.GroupMember;
 import com.helpie.backend.dto.chatroom.ChatRoomResponse;
 import com.helpie.backend.dto.chatroom.ChatMessageResponse;
@@ -32,7 +33,7 @@ import java.util.stream.Collectors;
  * 소모임 멤버만 접근 가능한 채팅방 관리를 담당합니다.
  * 
  * @author 전우선
- * @since 2025-10-25(토)
+ * @since 2025-10-30(토)
  */
 @Slf4j
 @Service
@@ -176,6 +177,49 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         return ChatMessageResponse.from(savedMessage);
     }
     
+    @Override
+    @Transactional
+    public Long createChatRoomAndJoin(Group group, Long userId, String userName, String welcomeMessage) {
+        log.debug("소모임 채팅방 생성 및 자동 입장 - groupId: {}, userId: {}", group.getId(), userId);
+        
+        // 1. 채팅방 생성
+        ChatRoom chatRoom = new ChatRoom(group);
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+        log.info("채팅방 자동 생성 완료 - chatRoomId: {}, groupId: {}", savedChatRoom.getId(), group.getId());
+        
+        // 2. 사용자 자동 입장
+        ChatRoomParticipant participant = new ChatRoomParticipant(savedChatRoom, userId);
+        participantRepository.save(participant);
+        log.info("채팅방 자동 입장 완료 - chatRoomId: {}, userId: {}", savedChatRoom.getId(), userId);
+        
+        // 3. 환영 메시지 전송
+        if (welcomeMessage != null && !welcomeMessage.isEmpty()) {
+            webSocketService.sendSystemMessage(savedChatRoom.getId(), welcomeMessage);
+        }
+        
+        return savedChatRoom.getId();
+    }
+    
+    @Override
+    @Transactional
+    public void autoJoinGroupChatRoom(Long groupId, Long userId, String userName, String joinMessage) {
+        log.debug("소모임 채팅방 자동 입장 - groupId: {}, userId: {}", groupId, userId);
+        
+        // 1. 채팅방 찾기
+        ChatRoom chatRoom = chatRoomRepository.findByGroupId(groupId)
+                .orElseThrow(() -> new IllegalStateException("채팅방이 존재하지 않습니다: " + groupId));
+        
+        // 2. 사용자 자동 입장
+        ChatRoomParticipant participant = new ChatRoomParticipant(chatRoom, userId);
+        participantRepository.save(participant);
+        log.info("채팅방 자동 입장 완료 - chatRoomId: {}, userId: {}", chatRoom.getId(), userId);
+        
+        // 3. 가입 메시지 전송
+        if (joinMessage != null && !joinMessage.isEmpty()) {
+            webSocketService.sendSystemMessage(chatRoom.getId(), joinMessage);
+        }
+    }
+
     /**
      * 소모임 멤버인지 확인합니다.
      */

--- a/src/main/java/com/helpie/backend/service/group/GroupService.java
+++ b/src/main/java/com/helpie/backend/service/group/GroupService.java
@@ -6,24 +6,31 @@ import com.helpie.backend.dto.group.GroupCreateRequest;
 import com.helpie.backend.dto.group.GroupCreateResponse;
 import com.helpie.backend.repository.group.GroupMemberRepository;
 import com.helpie.backend.repository.group.GroupRepository;
+import com.helpie.backend.service.chatroom.ChatRoomService;
 import com.helpie.backend.utils.storage.ImageStorage;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GroupService {
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final ChatRoomService chatRoomService;
     private final ImageStorage imageStorage;
 
     @Transactional
-    public GroupCreateResponse createGroup(Long userId,GroupCreateRequest req, List<MultipartFile> images) {
+    public GroupCreateResponse createGroup(Long userId, GroupCreateRequest req, List<MultipartFile> images) {
+        log.debug("소모임 생성 시작 - userId: {}, title: {}", userId, req.title());
 
+        // 1. 소모임 생성
         Group group = new Group(
             req.title(),
             req.description(),
@@ -32,22 +39,64 @@ public class GroupService {
             req.interests(),
             req.maxMember()
         );
+        Group savedGroup = groupRepository.save(group);
+        log.info("소모임 생성 완료 - groupId: {}", savedGroup.getId());
 
-        Group saved=groupRepository.save(group);
-        groupMemberRepository.save(new GroupMember(saved,userId));
-        List<String> urls=imageStorage.storeAll(images,group);
+        // 2. 소모임 멤버 추가
+        GroupMember groupMember = new GroupMember(savedGroup, userId);
+        groupMemberRepository.save(groupMember);
+        log.info("소모임 멤버 추가 완료 - groupId: {}, userId: {}", savedGroup.getId(), userId);
+
+        // 3. 채팅방 자동 생성 및 생성자 입장 (ChatRoomService에 위임)
+        String welcomeMessage = String.format("🎉 %s 소모임이 시작되었습니다! 즐거운 모임 되세요!", savedGroup.getTitle());
+        Long chatRoomId = chatRoomService.createChatRoomAndJoin(savedGroup, userId, null, welcomeMessage);
+
+        // 4. 이미지 저장
+        List<String> urls = imageStorage.storeAll(images, savedGroup);
+
+        log.info("소모임 생성 및 채팅방 자동 설정 완료 - groupId: {}, chatRoomId: {}", 
+                savedGroup.getId(), chatRoomId);
 
         return new GroupCreateResponse(
-            saved.getId(),
-            saved.getTitle(),
-            saved.getDescription(),
-            saved.getMaxMembers(),
-            saved.getCountry().name(),
-            saved.getInterests(),
+            savedGroup.getId(),
+            savedGroup.getTitle(),
+            savedGroup.getDescription(),
+            savedGroup.getMaxMembers(),
+            savedGroup.getCountry().name(),
+            savedGroup.getInterests(),
             urls
         );
-
     }
 
+    /**
+     * 소모임에 가입하고 채팅방에 자동 입장합니다.
+     */
+    @Transactional
+    public void joinGroup(Long groupId, Long userId, String userName) {
+        log.debug("소모임 가입 시작 - groupId: {}, userId: {}", groupId, userId);
+
+        // 1. 소모임 조회 및 검증
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 소모임입니다: " + groupId));
+
+        // 2. 중복 가입 검증
+        Optional<GroupMember> existingMember = groupMemberRepository.findByGroupIdAndUserId(groupId, userId);
+        if (existingMember.isPresent() && existingMember.get().getIsActive()) {
+            throw new IllegalStateException("이미 가입된 소모임입니다: " + groupId);
+        }
+
+        // 3. 소모임 멤버 추가
+        group.addMember(userId); // 현재 인원수 증가
+        GroupMember groupMember = new GroupMember(group, userId, userName, true);
+        groupMemberRepository.save(groupMember);
+        log.info("소모임 가입 완료 - groupId: {}, userId: {}", groupId, userId);
+
+        // 4. 채팅방에 자동 입장 (ChatRoomService에 위임)
+        String joinMessage = String.format("👋 %s님이 소모임에 참가하셨습니다! 환영해주세요!", 
+                userName != null ? userName : "새로운 멤버");
+        chatRoomService.autoJoinGroupChatRoom(groupId, userId, userName, joinMessage);
+
+        log.info("소모임 가입 및 채팅방 자동 입장 완료 - groupId: {}, userId: {}", groupId, userId);
+    }
 
 }


### PR DESCRIPTION
# PR 제목  
소모임 자동 입장 기능 구현 및 인원 제한 제거  

## 작업 내용  
- [x] 소모임 생성 시 채팅방 자동 생성 및 생성자 자동 입장  
- [x] 소모임 가입 시 채팅방 자동 입장 기능 구현  
- [x] 소모임 인원 제한 제거 (무제한 가입 가능)  
- [x] SOLID 원칙 적용: GroupService 책임 분리  
- [x] ChatRoomService에 자동 생성/입장 로직 위임  
- [x] 자동 입장 시 환영 메시지 및 가입 알림 시스템 개선  

## 체크리스트  
- [x] 코드 작성 완료  
- [x] 컴파일 테스트 완료   
- [x] 코드 스타일/컨벤션 확인  

## 관련 이슈  


## 참고 사항  
- 사용자가 소모임에 가입하면 별도 API 호출 없이 자동으로 채팅방에 입장됨  
- 기존 인원 제한(5명) → 무제한 가입 가능으로 변경  
- SRP 원칙 적용으로 GroupService와 ChatRoomService의 책임을 명확히 분리  
- 소모임 생성 시 환영 메시지, 가입 시 참가 알림 자동 전송  
- 기존 수동 입장 API(`/api/v1/chatrooms/{id}/enter`)도 여전히 사용 가능  
