### PR TITLE
feat: 도시 선택 기능 구현

### DIFF
--- a/src/main/java/com/helpie/backend/controller/survey/CountryController.java
+++ b/src/main/java/com/helpie/backend/controller/survey/CountryController.java
@@ -1,0 +1,98 @@
+package com.helpie.backend.controller.survey;
+
+import com.helpie.backend.domain.survey.Country;
+import com.helpie.backend.dto.global.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 도시/지역 선택 관련 컨트롤러
+ * 
+ * @author 전우선
+ * @since 2025-11-02(토)
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/countries")
+@Tag(name = "지역 선택", description = "도시/지역 선택 관련 API")
+@RequiredArgsConstructor
+public class CountryController {
+
+    /**
+     * 즐겨찾는 도시 5개를 조회합니다.
+     */
+    @GetMapping("/favorites")
+    @Operation(summary = "즐겨찾는 도시 조회", 
+               description = "전 세계 인기 도시 5개를 조회합니다. " +
+                           "서울, 도쿄, 상하이, 로스앤젤레스, 런던이 포함됩니다. " +
+                           "도시 선택 UI에서 우선 표시되는 도시들입니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public Response<List<CityResponse>> getFavoriteCities() {
+        log.info("즐겨찾는 도시 조회 요청");
+        
+        List<CityResponse> favoriteCities = Country.getFavoriteCities()
+                .stream()
+                .map(city -> new CityResponse(city.name(), city.getDescription()))
+                .toList();
+        
+        log.info("즐겨찾는 도시 조회 완료 - count: {}", favoriteCities.size());
+        return Response.success(favoriteCities);
+    }
+
+    /**
+     * 국가별로 그룹핑된 그 외 도시들을 조회합니다.
+     */
+    @GetMapping("/others")
+    @Operation(summary = "그 외 도시 조회", 
+               description = "국가별로 그룹핑된 전체 도시 목록을 조회합니다. " +
+                           "미국(7개), 한국(6개), 중국(4개), 일본(3개), 영국(4개) 등 " +
+                           "15개국 63개 도시가 국가별로 정리되어 있습니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public Response<Map<String, List<CityResponse>>> getOtherCitiesByCountry() {
+        log.info("그 외 도시 조회 요청");
+        
+        Map<String, List<CityResponse>> otherCities = Country.getOtherCitiesByCountry()
+                .entrySet()
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> entry.getValue()
+                            .stream()
+                            .map(city -> new CityResponse(city.name(), city.getDescription()))
+                            .toList(),
+                    (existing, replacement) -> existing,
+                    java.util.LinkedHashMap::new
+                ));
+        
+        log.info("그 외 도시 조회 완료 - countries: {}", otherCities.size());
+        return Response.success(otherCities);
+    }
+
+    /**
+     * 도시 응답 DTO
+     */
+    @Schema(description = "도시 정보 응답")
+    public record CityResponse(
+        @Schema(description = "도시 코드", example = "SEOUL")
+        String code,
+        @Schema(description = "도시 이름", example = "서울")
+        String name
+    ) {}
+}

--- a/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
+++ b/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
@@ -33,7 +33,10 @@ public class SurveyBasicInfoController {
      * 중복 등록 시 409 Conflict 응답이 반환됩니다.
      */
     @PostMapping("/basic-info")
-    @Operation(summary = "설문조사 기본정보 저장", description = "사용자의 나라, 성별, 나이대, 사용언어, 관심사 정보를 저장합니다.")
+    @Operation(summary = "설문조사 기본정보 저장", 
+               description = "사용자의 기본 프로필 정보를 저장합니다. " +
+                           "도시는 즐겨찾는 도시(서울, 도쿄, 상하이, 로스앤젤레스, 런던) 또는 " +
+                           "기타 도시(미국-뉴욕, 한국-부산, 중국-베이징 등)에서 선택 가능합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "저장 성공"),
         @ApiResponse(responseCode = "400", description = "필수값 누락 또는 유효하지 않은 값"),
@@ -45,8 +48,8 @@ public class SurveyBasicInfoController {
             @RequestParam Long userId,
             @Valid @RequestBody SurveyBasicInfoRequest request) {
         
-        log.info("설문조사 기본정보 저장 요청 - userId: {}, country: {}, gender: {}", 
-                 userId, request.getCountry(), request.getGender());
+        log.info("설문조사 기본정보 저장 요청 - userId: {}, city: {}, gender: {}", 
+                 userId, request.getCity(), request.getGender());
         
         surveyBasicInfoService.saveSurveyBasicInfo(userId, request);
         
@@ -59,7 +62,9 @@ public class SurveyBasicInfoController {
      * 등록된 정보가 없을 시 404 Not Found 응답이 반환됩니다.
      */
     @PutMapping("/basic-info")
-    @Operation(summary = "설문조사 기본정보 수정", description = "기존에 등록된 설문조사 기본정보를 수정합니다.")
+    @Operation(summary = "설문조사 기본정보 수정", 
+               description = "기존에 등록된 설문조사 기본정보를 수정합니다. " +
+                           "도시는 즐겨찾는 도시 또는 기타 도시에서 선택 가능합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "수정 성공"),
         @ApiResponse(responseCode = "400", description = "필수값 누락 또는 유효하지 않은 값"),
@@ -71,8 +76,8 @@ public class SurveyBasicInfoController {
             @RequestParam Long userId,
             @Valid @RequestBody SurveyBasicInfoRequest request) {
         
-        log.info("설문조사 기본정보 수정 요청 - userId: {}, country: {}, gender: {}", 
-                 userId, request.getCountry(), request.getGender());
+        log.info("설문조사 기본정보 수정 요청 - userId: {}, city: {}, gender: {}", 
+                 userId, request.getCity(), request.getGender());
         
         surveyBasicInfoService.updateSurveyBasicInfo(userId, request);
         

--- a/src/main/java/com/helpie/backend/domain/group/Group.java
+++ b/src/main/java/com/helpie/backend/domain/group/Group.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * 소모임 엔티티 나라와 관심사를 기반으로 매칭된 소모임 (정원 5명)
+ * 소모임 엔티티 도시와 관심사를 기반으로 매칭된 소모임 (정원 5명)
  *
  * @author 전우선
  * @since 2025-10-30(목)
@@ -40,8 +40,8 @@ public class Group {
     private String description;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "country", nullable = false)
-    private Country country;
+    @Column(name = "city", nullable = false)
+    private Country city;
 
     @ElementCollection(targetClass = Interest.class)
     @Enumerated(EnumType.STRING)
@@ -81,12 +81,12 @@ public class Group {
     @Column(name = "created_by")
     private Long createdBy;
 
-    public Group(String title, String description, Country country, Set<Interest> interests,
+    public Group(String title, String description, Country city, Set<Interest> interests,
         Category category, Integer maxMembers, Integer currentMembers, GroupStatus status,
         Long createdBy) {
         this.title = title;
         this.description = description;
-        this.country = country;
+        this.city = city;
         this.interests = interests != null ? new HashSet<>(interests) : new HashSet<>();
         this.category = category;
         this.status = status != null ? status : GroupStatus.ACTIVE;
@@ -97,9 +97,9 @@ public class Group {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public Group(String title, String description, Country country, Category category,
+    public Group(String title, String description, Country city, Category category,
         Set<Interest> interests, Integer maxMember) {
-        this(title, description, country, interests, category, maxMember, 0, GroupStatus.ACTIVE,
+        this(title, description, city, interests, category, maxMember, 0, GroupStatus.ACTIVE,
             null);
     }
 

--- a/src/main/java/com/helpie/backend/domain/survey/Country.java
+++ b/src/main/java/com/helpie/backend/domain/survey/Country.java
@@ -1,18 +1,105 @@
 package com.helpie.backend.domain.survey;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
- * 국가 선택 Enum
+ * 도시 선택 Enum (계층적 구조: 국가 > 도시)
  * 
  * @author 전우선
  * @since 2025-10-19(일)
  */
 public enum Country {
-    KOREA("한국"),
-    USA("미국"),
-    CHINA("중국"),
-    JAPAN("일본"),
-    UK("영국"),
-    OTHER("그 외 나라");
+    // 즐겨찾는 도시 5개
+    SEOUL("서울"),
+    TOKYO("도쿄"), 
+    SHANGHAI("상하이"),
+    LOS_ANGELES("로스앤젤레스"),
+    LONDON("런던"),
+    
+    // 그 외 도시들
+    // 미국
+    USA_LOS_ANGELES("미국 - 로스앤젤레스"),
+    USA_NEW_YORK("미국 - 뉴욕"),
+    USA_BOSTON("미국 - 보스턴"),
+    USA_SAN_FRANCISCO("미국 - 샌프란시스코"),
+    USA_CHICAGO("미국 - 시카고"),
+    USA_WASHINGTON("미국 - 워싱턴"),
+    USA_AUSTIN("미국 - 어스틴"),
+    
+    // 한국
+    KOREA_SEOUL("한국 - 서울"),
+    KOREA_BUSAN("한국 - 부산"),
+    KOREA_JEJU("한국 - 제주"),
+    KOREA_INCHEON("한국 - 인천"),
+    KOREA_GANGNEUNG("한국 - 강릉"),
+    KOREA_GWANGJU("한국 - 광주"),
+    
+    // 중국
+    CHINA_SHANGHAI("중국 - 상하이"),
+    CHINA_BEIJING("중국 - 베이징"),
+    CHINA_HANGZHOU("중국 - 항저우"),
+    CHINA_HONGKONG("중국 - 홍콩"),
+    
+    // 싱가포르
+    SINGAPORE("싱가포르"),
+    
+    // 일본
+    JAPAN_TOKYO("일본 - 도쿄"),
+    JAPAN_OSAKA("일본 - 오사카"),
+    JAPAN_KYOTO("일본 - 교토"),
+    
+    // 영국
+    UK_LONDON("영국 - 런던"),
+    UK_MANCHESTER("영국 - 멘체스터"),
+    UK_OXFORD("영국 - 옥스퍼드"),
+    UK_CAMBRIDGE("영국 - 캠브리지"),
+    
+    // 호주
+    AUSTRALIA_SYDNEY("호주 - 시드니"),
+    AUSTRALIA_MELBOURNE("호주 - 멜버른"),
+    AUSTRALIA_BRISBANE("호주 - 브리즈번"),
+    AUSTRALIA_PERTH("호주 - 펄스"),
+    
+    // 캐나다
+    CANADA_TORONTO("캐나다 - 토론토"),
+    CANADA_VANCOUVER("캐나다 - 벤쿠버"),
+    CANADA_MONTREAL("캐나다 - 몬트리올"),
+    
+    // 독일
+    GERMANY_BERLIN("독일 - 베를린"),
+    GERMANY_MUNICH("독일 - 뮈헨"),
+    GERMANY_HEIDELBERG("독일 - 하이델베르크"),
+    GERMANY_HAMBURG("독일 - 함부르크"),
+    
+    // 프랑스
+    FRANCE_PARIS("프랑스 - 파리"),
+    FRANCE_LYON("프랑스 - 리옹"),
+    
+    // 이탈리아
+    ITALY_ROME("이탈리아 - 로마"),
+    ITALY_MILAN("이탈리아 - 밀라노"),
+    ITALY_BOLOGNA("이탈리아 - 볼로냐"),
+    
+    // 네덜란드
+    NETHERLANDS_AMSTERDAM("네덜란드 - 암스테르담"),
+    NETHERLANDS_ROTTERDAM("네덜란드 - 로테르담"),
+    
+    // 스페인
+    SPAIN_BARCELONA("스페인 - 바르셀로나"),
+    SPAIN_MADRID("스페인 - 마드리드"),
+    SPAIN_VALENCIA("스페인 - 발렌시아"),
+    
+    // 노르웨이
+    NORWAY_OSLO("노르웨이 - 오슬로"),
+    NORWAY_TRONDHEIM("노르웨이 - 트론드하임"),
+    
+    // 스위스
+    SWITZERLAND_ZURICH("스위스 - 취리히"),
+    
+    // 아랍에미리트
+    UAE_DUBAI("아랍에미리트 - 두바이");
 
     private final String description;
 
@@ -22,5 +109,106 @@ public enum Country {
 
     public String getDescription() {
         return description;
+    }
+    
+    /**
+     * 즐겨찾는 도시 5개를 반환합니다.
+     */
+    public static List<Country> getFavoriteCities() {
+        return List.of(SEOUL, TOKYO, SHANGHAI, LOS_ANGELES, LONDON);
+    }
+    
+    /**
+     * 국가별로 그룹핑된 그 외 도시들을 반환합니다.
+     */
+    public static Map<String, List<Country>> getOtherCitiesByCountry() {
+        Map<String, List<Country>> grouped = new LinkedHashMap<>();
+        
+        // 미국
+        grouped.put("미국", List.of(
+            LOS_ANGELES, USA_LOS_ANGELES, USA_NEW_YORK, USA_BOSTON, USA_SAN_FRANCISCO, 
+            USA_CHICAGO, USA_WASHINGTON, USA_AUSTIN
+        ));
+        
+        // 한국  
+        grouped.put("한국", List.of(
+            SEOUL, KOREA_SEOUL, KOREA_BUSAN, KOREA_JEJU, 
+            KOREA_INCHEON, KOREA_GANGNEUNG, KOREA_GWANGJU
+        ));
+        
+        // 중국
+        grouped.put("중국", List.of(
+            SHANGHAI, CHINA_SHANGHAI, CHINA_BEIJING, CHINA_HANGZHOU, CHINA_HONGKONG
+        ));
+        
+        // 싱가포르
+        grouped.put("싱가포르", List.of(SINGAPORE));
+        
+        // 일본
+        grouped.put("일본", List.of(
+            TOKYO, JAPAN_TOKYO, JAPAN_OSAKA, JAPAN_KYOTO
+        ));
+        
+        // 영국
+        grouped.put("영국", List.of(
+            LONDON, UK_LONDON, UK_MANCHESTER, UK_OXFORD, UK_CAMBRIDGE
+        ));
+        
+        // 호주
+        grouped.put("호주", List.of(
+            AUSTRALIA_SYDNEY, AUSTRALIA_MELBOURNE, 
+            AUSTRALIA_BRISBANE, AUSTRALIA_PERTH
+        ));
+        
+        // 캐나다
+        grouped.put("캐나다", List.of(
+            CANADA_TORONTO, CANADA_VANCOUVER, CANADA_MONTREAL
+        ));
+        
+        // 독일
+        grouped.put("독일", List.of(
+            GERMANY_BERLIN, GERMANY_MUNICH, 
+            GERMANY_HEIDELBERG, GERMANY_HAMBURG
+        ));
+        
+        // 프랑스
+        grouped.put("프랑스", List.of(
+            FRANCE_PARIS, FRANCE_LYON
+        ));
+        
+        // 이탈리아
+        grouped.put("이탈리아", List.of(
+            ITALY_ROME, ITALY_MILAN, ITALY_BOLOGNA
+        ));
+        
+        // 네덜란드
+        grouped.put("네덜란드", List.of(
+            NETHERLANDS_AMSTERDAM, NETHERLANDS_ROTTERDAM
+        ));
+        
+        // 스페인
+        grouped.put("스페인", List.of(
+            SPAIN_BARCELONA, SPAIN_MADRID, SPAIN_VALENCIA
+        ));
+        
+        // 노르웨이
+        grouped.put("노르웨이", List.of(
+            NORWAY_OSLO, NORWAY_TRONDHEIM
+        ));
+        
+        // 스위스
+        grouped.put("스위스", List.of(SWITZERLAND_ZURICH));
+        
+        // 아랍에미리트
+        grouped.put("아랍에미리트", List.of(UAE_DUBAI));
+        
+        return grouped;
+    }
+    
+    /**
+     * 즐겨찾는 도시인지 확인합니다.
+     */
+    public boolean isFavorite() {
+        return getFavoriteCities().contains(this);
     }
 }

--- a/src/main/java/com/helpie/backend/domain/survey/SurveyBasicInfo.java
+++ b/src/main/java/com/helpie/backend/domain/survey/SurveyBasicInfo.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 /**
  * 설문조사 기본정보 엔티티
- * 사용자의 기본 프로필 정보(나라, 성별, 나이대, 언어, 관심사)를 관리합니다.
+ * 사용자의 기본 프로필 정보(도시, 성별, 나이대, 언어, 관심사)를 관리합니다.
  * 
  * @author 전우선
  * @since 2025-10-19(일)
@@ -41,8 +41,8 @@ public class SurveyBasicInfo {
     private AgeGroup ageGroup;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "country", nullable = false)
-    private Country country;
+    @Column(name = "city", nullable = false)
+    private Country city;
 
     /** 복수 선택 가능한 사용 언어 목록 */
     @ElementCollection(targetClass = Language.class)
@@ -64,9 +64,9 @@ public class SurveyBasicInfo {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public SurveyBasicInfo(Long userId, Country country, Gender gender, AgeGroup ageGroup, Set<Language> languages, Set<Interest> interests) {
+    public SurveyBasicInfo(Long userId, Country city, Gender gender, AgeGroup ageGroup, Set<Language> languages, Set<Interest> interests) {
         this.userId = userId;
-        this.country = country;
+        this.city = city;
         this.gender = gender;
         this.ageGroup = ageGroup;
         this.languages = languages;
@@ -83,8 +83,8 @@ public class SurveyBasicInfo {
     /**
      * 기본정보를 새로운 값으로 업데이트합니다.
      */
-    public void updateBasicInfo(Country country, Gender gender, AgeGroup ageGroup, Set<Language> languages, Set<Interest> interests) {
-        this.country = country;
+    public void updateBasicInfo(Country city, Gender gender, AgeGroup ageGroup, Set<Language> languages, Set<Interest> interests) {
+        this.city = city;
         this.gender = gender;
         this.ageGroup = ageGroup;
         this.languages = languages;

--- a/src/main/java/com/helpie/backend/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupCreateRequest.java
@@ -13,8 +13,11 @@ public record GroupCreateRequest(
     String title,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     String description,
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    Country country,
+    @Schema(description = "소모임 위치 도시 (즐겨찾는 도시나 기타 도시 선택)", 
+            example = "SEOUL", requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"SEOUL", "TOKYO", "SHANGHAI", "LOS_ANGELES", "LONDON", 
+                              "USA_NEW_YORK", "KOREA_BUSAN", "CHINA_BEIJING"})
+    Country city,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     Set<Interest> interests,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
@@ -7,7 +7,7 @@ import com.helpie.backend.domain.survey.Country;
 public record GroupResponse(
     String title,
     String description,
-    Country country,
+    Country city,
     Category category,
     Integer maxMember,
     String thumbnail,
@@ -17,7 +17,7 @@ public record GroupResponse(
         return new GroupResponse(
             group.getTitle(),
             group.getDescription(),
-            group.getCountry(),
+            group.getCity(),
             group.getCategory(),
             group.getMaxMembers(),
             null,

--- a/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoRequest.java
+++ b/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoRequest.java
@@ -28,9 +28,12 @@ import java.util.Set;
 @AllArgsConstructor
 public class SurveyBasicInfoRequest {
 
-    @Schema(description = "국가", example = "KOREA", required = true)
-    @NotNull(message = "나라는 필수입니다.")
-    private Country country;
+    @Schema(description = "도시 (즐겨찾는 도시: SEOUL, TOKYO, SHANGHAI, LOS_ANGELES, LONDON 또는 기타 도시들)", 
+            example = "SEOUL", required = true, 
+            allowableValues = {"SEOUL", "TOKYO", "SHANGHAI", "LOS_ANGELES", "LONDON", 
+                              "USA_NEW_YORK", "KOREA_BUSAN", "CHINA_BEIJING", "JAPAN_OSAKA", "UK_MANCHESTER"})
+    @NotNull(message = "도시는 필수입니다.")
+    private Country city;
 
     @Schema(description = "성별", example = "MALE", required = true)
     @NotNull(message = "성별은 필수입니다.")

--- a/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoResponse.java
+++ b/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoResponse.java
@@ -26,7 +26,7 @@ public class SurveyBasicInfoResponse {
     
     private Long id;
     private Long userId;
-    private Country country;
+    private Country city;
     private Gender gender;
     private AgeGroup ageGroup;
     private Set<Language> languages;
@@ -38,7 +38,7 @@ public class SurveyBasicInfoResponse {
         return new SurveyBasicInfoResponse(
                 surveyBasicInfo.getId(),
                 surveyBasicInfo.getUserId(),
-                surveyBasicInfo.getCountry(),
+                surveyBasicInfo.getCity(),
                 surveyBasicInfo.getGender(),
                 surveyBasicInfo.getAgeGroup(),
                 surveyBasicInfo.getLanguages(),

--- a/src/main/java/com/helpie/backend/repository/group/GroupRepository.java
+++ b/src/main/java/com/helpie/backend/repository/group/GroupRepository.java
@@ -25,7 +25,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     /**
      * 나라별, 상태별 소모임 목록을 조회합니다.
      */
-    List<Group> findByCountryAndStatus(Country country, GroupStatus status);
+    List<Group> findByCityAndStatus(Country city, GroupStatus status);
     
     /**
      * 활성 상태인 소모임 목록을 조회합니다.
@@ -34,17 +34,17 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     @Query("""
     SELECT g FROM Group g
-    WHERE g.country = :country
+    WHERE g.city = :city
       AND (:category = 'ALL' OR g.category = :category)
       AND g.status IN :statuses
 """)
-    Page<Group> findAllByFilters(@Param("country") Country country, @Param("category") Category category, @Param("statuses") List<GroupStatus> statuses, Pageable pageable);
+    Page<Group> findAllByFilters(@Param("city") Country city, @Param("category") Category category, @Param("statuses") List<GroupStatus> statuses, Pageable pageable);
 
 
 
     @Query("""
     SELECT g FROM Group g
-    WHERE g.country = :country
+    WHERE g.city = :city
       AND g.status IN :statuses
        AND EXISTS (
            SELECT i FROM g.interests i
@@ -52,5 +52,5 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
           )
 
 """)
-    Page<Group> findByInterestFilters(@Param("country") Country country, @Param("statuses") List<GroupStatus> statuses,@Param("interests") Set<Interest> interests, Pageable pageable);
+    Page<Group> findByInterestFilters(@Param("city") Country city, @Param("statuses") List<GroupStatus> statuses,@Param("interests") Set<Interest> interests, Pageable pageable);
 }

--- a/src/main/java/com/helpie/backend/service/group/GroupService.java
+++ b/src/main/java/com/helpie/backend/service/group/GroupService.java
@@ -45,7 +45,7 @@ public class GroupService {
         Group group = new Group(
             req.title(),
             req.description(),
-            req.country(),
+            req.city(),
             req.category(),
             req.interests(),
             req.maxMember()
@@ -73,7 +73,7 @@ public class GroupService {
             savedGroup.getTitle(),
             savedGroup.getDescription(),
             savedGroup.getMaxMembers(),
-            savedGroup.getCountry().name(),
+            savedGroup.getCity().name(),
             savedGroup.getInterests(),
             urls
         );
@@ -112,8 +112,8 @@ public class GroupService {
 
     public Page<GroupResponse> getGroups(Long userId, Category category, Pageable pageable) {
         Country country = surveyBasicInfoRepository.findByUserId(userId)
-            .map(SurveyBasicInfo::getCountry)
-            .orElse(Country.KOREA);
+            .map(SurveyBasicInfo::getCity)
+            .orElseThrow(() -> new IllegalStateException("설문조사 기본정보를 먼저 작성해주세요."));
 
         List<GroupStatus> visibleStatuses = List.of(GroupStatus.ACTIVE, GroupStatus.FULL);
 
@@ -125,8 +125,8 @@ public class GroupService {
 
     public Page<GroupResponse> getGroupsByInterest(Long userId, Pageable pageable) {
         Country country = surveyBasicInfoRepository.findByUserId(userId)
-            .map(SurveyBasicInfo::getCountry)
-            .orElse(Country.KOREA);
+            .map(SurveyBasicInfo::getCity)
+            .orElseThrow(() -> new IllegalStateException("설문조사 기본정보를 먼저 작성해주세요."));
 
         Set<Interest> interests=surveyBasicInfoRepository.findByUserId(userId).map(SurveyBasicInfo::getInterests).orElse(null);
 

--- a/src/main/java/com/helpie/backend/service/survey/SurveyBasicInfoServiceImpl.java
+++ b/src/main/java/com/helpie/backend/service/survey/SurveyBasicInfoServiceImpl.java
@@ -58,7 +58,7 @@ public class SurveyBasicInfoServiceImpl implements SurveyBasicInfoService {
     private SurveyBasicInfo createSurveyBasicInfo(Long userId, SurveyBasicInfoRequest request) {
         return new SurveyBasicInfo(
                 userId,
-                request.getCountry(),
+                request.getCity(),
                 request.getGender(),
                 request.getAgeGroup(),
                 request.getLanguages(),
@@ -76,7 +76,7 @@ public class SurveyBasicInfoServiceImpl implements SurveyBasicInfoService {
 
     private void updateSurveyBasicInfoData(SurveyBasicInfo surveyBasicInfo, SurveyBasicInfoRequest request) {
         surveyBasicInfo.updateBasicInfo(
-                request.getCountry(),
+                request.getCity(),
                 request.getGender(),
                 request.getAgeGroup(),
                 request.getLanguages(),


### PR DESCRIPTION
# 전세계 도시 선택 기능 구현 

  ## 작업 내용
  - [x] Country enum에 15개국 63개 도시 추가 (즐겨찾는 도시 5개 + 기타 58개)
  - [x] 즐겨찾는 도시 조회 API 구현 (`GET /api/v1/countries/favorites`)
  - [x] 국가별 도시 조회 API 구현 (`GET /api/v1/countries/others`)
  - [x] Country enum 변경으로 영향받는 모든 코드 수정 및 컴파일 오류 해결
  - [x] Swagger API 문서 대폭 업데이트 (도시 선택 방식 상세 설명)
  - [x] GroupService 기본값 로직 개선 (설문조사 필수 선행 조건 강화)

  ## 체크리스트
  - [x] 코드 작성 완료
  - [x] 컴파일 오류 수정 완료
  - [x] Swagger 문서 업데이트 완료
  - [x] API 응답 구조 최적화 완료

  ## 주요 변경사항
  **Country enum 확장:**
  - 즐겨찾는 도시: 서울, 도쿄, 상하이, 로스앤젤레스, 런던
  - 15개국 도시: 미국(7개), 한국(6개), 중국(4개), 일본(3개), 영국(4개) 등

  **API 엔드포인트:**
  - `GET /api/v1/countries/favorites` - 즐겨찾는 도시 5개 조회
  - `GET /api/v1/countries/others` - 국가별 그룹핑된 전체 도시 조회

  **비즈니스 로직 개선:**
  - 설문조사 미완료 시 소모임 조회 시 명확한 에러 메시지 제공

  ## 참고 사항
  - 설문조사 완료가 소모임 기능 사용의 선행 조건임
