### PR TITLE
refactor: userId 파라미터 제거 및 인증 사용자 기반으로 변경

### DIFF
--- a/src/main/java/com/helpie/backend/config/SecurityConfig.java
+++ b/src/main/java/com/helpie/backend/config/SecurityConfig.java
@@ -107,6 +107,14 @@ public class SecurityConfig {
             "/api/v1/countries/**"
     };
 
+    private static final String[] SURVEY_URIS = {
+            "/api/v1/surveys/**"
+    };
+
+    private static final String[] GROUP_URIS = {
+            "/api/v1/group/**"
+    };
+
     private static final String[] CHATROOM_API_URIS = {
             "/api/v1/chatrooms/**"
     };
@@ -144,12 +152,15 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_URIS).permitAll()
                         // WebSocket 엔드포인트 허용
                         .requestMatchers(WEBSOCKET_URIS).permitAll()
-                        // 채팅방 API 허용
-                        .requestMatchers(CHATROOM_API_URIS).permitAll()
+                        // 채팅방 API도 JWT 인증 필요로 변경
+                        // .requestMatchers(CHATROOM_API_URIS).permitAll()
                         .requestMatchers(LOCATION_URIS).permitAll()
                         .requestMatchers(COUNTRY_URIS).permitAll()
-                        // 모든 요청을 인증 없이 허용 (개발 환경용)
-                        // TODO: API별 세분화된 권한 설정 필요
+                        // JWT 인증 필수 API들 - @Secured 어노테이션으로 보호
+                        // .requestMatchers(SURVEY_URIS).authenticated()  // JWT 토큰 필요
+                        // .requestMatchers(GROUP_URIS).authenticated()   // JWT 토큰 필요  
+                        // .requestMatchers(CHATROOM_API_URIS).authenticated()  // JWT 토큰 필요
+                        // 모든 요청을 인증 필수로 변경 (JWT 적용 완료)
                         .anyRequest()
                         .authenticated()
                 )

--- a/src/main/java/com/helpie/backend/controller/chatroom/ChatRoomController.java
+++ b/src/main/java/com/helpie/backend/controller/chatroom/ChatRoomController.java
@@ -1,11 +1,14 @@
 package com.helpie.backend.controller.chatroom;
 
+import com.helpie.backend.domain.user.UserRole;
+import com.helpie.backend.domain.user.UserVo;
 import com.helpie.backend.dto.chatroom.ChatRoomResponse;
 import com.helpie.backend.dto.chatroom.ChatMessageResponse;
 import com.helpie.backend.dto.chatroom.SendMessageRequest;
 import com.helpie.backend.service.chatroom.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -40,6 +45,8 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
     
     @PostMapping("/{chatRoomId}/enter")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(
         summary = "채팅방 입장", 
         description = "소모임 멤버가 채팅방에 입장합니다.\n\n" +
@@ -50,26 +57,30 @@ public class ChatRoomController {
                      "**참고:** 실제 실시간 채팅은 WebSocket `/ws/chat` 연결이 필요합니다."
     )
     public ResponseEntity<ChatRoomResponse> enterChatRoom(
+        @AuthenticationPrincipal UserVo userVo,
         @Parameter(description = "채팅방 ID") @PathVariable Long chatRoomId,
-        @Parameter(description = "사용자 ID") @RequestParam Long userId,
         @Parameter(description = "사용자 이름") @RequestParam String userName
     ) {
-        ChatRoomResponse response = chatRoomService.enterChatRoom(chatRoomId, userId, userName);
+        ChatRoomResponse response = chatRoomService.enterChatRoom(chatRoomId, userVo.getId(), userName);
         return ResponseEntity.ok(response);
     }
     
     @PostMapping("/{chatRoomId}/leave")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(summary = "채팅방 퇴장", description = "채팅방에서 퇴장합니다. 퇴장 시 시스템 메시지가 자동 전송됩니다.")
     public ResponseEntity<Void> leaveChatRoom(
+        @AuthenticationPrincipal UserVo userVo,
         @Parameter(description = "채팅방 ID") @PathVariable Long chatRoomId,
-        @Parameter(description = "사용자 ID") @RequestParam Long userId,
         @Parameter(description = "사용자 이름") @RequestParam String userName
     ) {
-        chatRoomService.leaveChatRoom(chatRoomId, userId, userName);
+        chatRoomService.leaveChatRoom(chatRoomId, userVo.getId(), userName);
         return ResponseEntity.ok().build();
     }
     
     @GetMapping("/accessible")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(
         summary = "접근 가능한 채팅방 목록", 
         description = "사용자가 접근 가능한 채팅방 목록을 조회합니다.\n\n" +
@@ -79,23 +90,27 @@ public class ChatRoomController {
                      "- 활성 상태인 채팅방만 포함"
     )
     public ResponseEntity<List<ChatRoomResponse>> getAccessibleChatRooms(
-        @Parameter(description = "사용자 ID") @RequestParam Long userId
+        @AuthenticationPrincipal UserVo userVo
     ) {
-        List<ChatRoomResponse> response = chatRoomService.getAccessibleChatRooms(userId);
+        List<ChatRoomResponse> response = chatRoomService.getAccessibleChatRooms(userVo.getId());
         return ResponseEntity.ok(response);
     }
     
     @GetMapping("/{chatRoomId}")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(summary = "채팅방 상세 조회", description = "채팅방의 상세 정보를 조회합니다.")
     public ResponseEntity<ChatRoomResponse> getChatRoomDetail(
-        @Parameter(description = "채팅방 ID") @PathVariable Long chatRoomId,
-        @Parameter(description = "사용자 ID") @RequestParam Long userId
+        @AuthenticationPrincipal UserVo userVo,
+        @Parameter(description = "채팅방 ID") @PathVariable Long chatRoomId
     ) {
-        ChatRoomResponse response = chatRoomService.getChatRoomDetail(chatRoomId, userId);
+        ChatRoomResponse response = chatRoomService.getChatRoomDetail(chatRoomId, userVo.getId());
         return ResponseEntity.ok(response);
     }
     
     @GetMapping("/{chatRoomId}/messages")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(
         summary = "채팅방 메시지 조회 (페이징 최적화)",
         description = "채팅방의 메시지 목록을 페이징하여 조회합니다.\n\n" +
@@ -109,12 +124,12 @@ public class ChatRoomController {
                      "- 이전 메시지: `?page=1&size=20`"
     )
     public ResponseEntity<Page<ChatMessageResponse>> getChatMessages(
+        @AuthenticationPrincipal UserVo userVo,
         @Parameter(description = "채팅방 ID") @PathVariable Long chatRoomId,
-        @Parameter(description = "사용자 ID") @RequestParam Long userId,
         @Parameter(description = "페이징 정보 (기본: 50개, 최신순)") 
         @PageableDefault(size = 50, sort = "sentAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<ChatMessageResponse> response = chatRoomService.getChatMessages(chatRoomId, userId, pageable);
+        Page<ChatMessageResponse> response = chatRoomService.getChatMessages(chatRoomId, userVo.getId(), pageable);
         return ResponseEntity.ok(response);
     }
     

--- a/src/main/java/com/helpie/backend/controller/group/GroupController.java
+++ b/src/main/java/com/helpie/backend/controller/group/GroupController.java
@@ -1,11 +1,14 @@
 package com.helpie.backend.controller.group;
 
 import com.helpie.backend.domain.group.Category;
+import com.helpie.backend.domain.user.UserRole;
+import com.helpie.backend.domain.user.UserVo;
 import com.helpie.backend.dto.group.GroupCreateRequest;
 import com.helpie.backend.dto.group.GroupCreateResponse;
 import com.helpie.backend.dto.group.GroupResponse;
 import com.helpie.backend.service.group.GroupService;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,36 +38,42 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     public ResponseEntity<GroupCreateResponse> createGroup(
-        @Parameter(description = "사용자 ID") @RequestParam Long userId,
+        @AuthenticationPrincipal UserVo userVo,
         @Parameter(description = "소모임 생성 정보 (cityId는 도시 ID)") @RequestPart("payload") GroupCreateRequest request,
         @Parameter(description = "사진")@RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
 
-        GroupCreateResponse response = groupService.createGroup(userId,request, images);
+        GroupCreateResponse response = groupService.createGroup(userVo.getId(),request, images);
 
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/list")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     public ResponseEntity<Page<GroupResponse>> getGroups(
+        @AuthenticationPrincipal UserVo userVo,
         @Parameter(description = "소모임 카테고리") @RequestParam Category category,
-        @Parameter(description = "사용자 ID") @RequestParam Long userId,
         @RequestParam(defaultValue ="0") int page,
         @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ){
-        Page<GroupResponse> response=groupService.getGroups(userId,category,pageable);
+        Page<GroupResponse> response=groupService.getGroups(userVo.getId(),category,pageable);
         return ResponseEntity.ok(response);
     }
 
 
     @GetMapping("/interest")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     public ResponseEntity<Page<GroupResponse>> getGroupsByInterest(
-        @Parameter(description = "사용자 ID") @RequestParam Long userId,
+        @AuthenticationPrincipal UserVo userVo,
         @RequestParam(defaultValue ="0") int page,
         @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ){
-        Page<GroupResponse> response=groupService.getGroupsByInterest(userId,pageable);
+        Page<GroupResponse> response=groupService.getGroupsByInterest(userVo.getId(),pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
+++ b/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
@@ -1,16 +1,21 @@
 package com.helpie.backend.controller.survey;
 
+import com.helpie.backend.domain.user.UserRole;
+import com.helpie.backend.domain.user.UserVo;
 import com.helpie.backend.dto.survey.SurveyBasicInfoRequest;
 import com.helpie.backend.service.survey.SurveyBasicInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -33,6 +38,8 @@ public class SurveyBasicInfoController {
      * 중복 등록 시 409 Conflict 응답이 반환됩니다.
      */
     @PostMapping("/basic-info")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(summary = "설문조사 기본정보 저장", 
                description = "사용자의 기본 프로필 정보를 저장합니다. " +
                            "cityId는 /api/v1/locations/cities/favorites 또는 /api/v1/locations/cities에서 조회한 도시 ID를 사용합니다. " +
@@ -44,16 +51,15 @@ public class SurveyBasicInfoController {
         @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ResponseEntity<Void> saveSurveyBasicInfo(
-            @Parameter(description = "사용자 ID", required = true, example = "1")
-            @RequestParam Long userId,
+            @AuthenticationPrincipal UserVo userVo,
             @Valid @RequestBody SurveyBasicInfoRequest request) {
         
         log.info("설문조사 기본정보 저장 요청 - userId: {}, cityId: {}, gender: {}", 
-                 userId, request.getCity(), request.getGender());
+                 userVo.getId(), request.getCity(), request.getGender());
         
-        surveyBasicInfoService.saveSurveyBasicInfo(userId, request);
+        surveyBasicInfoService.saveSurveyBasicInfo(userVo.getId(), request);
         
-        log.info("설문조사 기본정보 저장 완료 - userId: {}", userId);
+        log.info("설문조사 기본정보 저장 완료 - userId: {}", userVo.getId());
         return ResponseEntity.ok().build();
     }
 
@@ -62,6 +68,8 @@ public class SurveyBasicInfoController {
      * 등록된 정보가 없을 시 404 Not Found 응답이 반환됩니다.
      */
     @PutMapping("/basic-info")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
     @Operation(summary = "설문조사 기본정보 수정", 
                description = "기존에 등록된 설문조사 기본정보를 수정합니다. " +
                            "cityId는 /api/v1/locations/cities/favorites 또는 /api/v1/locations/cities에서 조회한 도시 ID를 사용합니다.")
@@ -72,16 +80,15 @@ public class SurveyBasicInfoController {
         @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ResponseEntity<Void> updateSurveyBasicInfo(
-            @Parameter(description = "사용자 ID", required = true, example = "1")
-            @RequestParam Long userId,
+            @AuthenticationPrincipal UserVo userVo,
             @Valid @RequestBody SurveyBasicInfoRequest request) {
         
         log.info("설문조사 기본정보 수정 요청 - userId: {}, cityId: {}, gender: {}", 
-                 userId, request.getCity(), request.getGender());
+                 userVo.getId(), request.getCity(), request.getGender());
         
-        surveyBasicInfoService.updateSurveyBasicInfo(userId, request);
+        surveyBasicInfoService.updateSurveyBasicInfo(userVo.getId(), request);
         
-        log.info("설문조사 기본정보 수정 완료 - userId: {}", userId);
+        log.info("설문조사 기본정보 수정 완료 - userId: {}", userVo.getId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/helpie/backend/domain/location/Country.java
+++ b/src/main/java/com/helpie/backend/domain/location/Country.java
@@ -29,7 +29,7 @@ public class Country {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "code", nullable = false, unique = true, length = 10)
+    @Column(name = "code", nullable = false, unique = true, length = 20)
     private String code; // USA, KOREA, CHINA, etc.
 
     @Column(name = "name", nullable = false, length = 50)


### PR DESCRIPTION
# userId 파라미터 제거 및 인증 사용자 기반으로 변경

  ## 작업 내용
  - [x] 설문조사, 소모임, 채팅방 API에서 cityId 기반으로 변경
  - [x] JWT 인증 시스템 적용 (userId 파라미터 제거)
  - [x] Country code 컬럼 길이 확장 (10 → 20)
  - [x] 데이터베이스 마이그레이션 스크립트 작성

  ## 체크리스트
  - [x] 코드 작성 완료
  - [x] 컴파일 오류 수정 완료
  - [x] Swagger 문서 업데이트
  - [x] JWT 보안 설정 적용
  - [x] 코드 스타일/컨벤션 확인

  ## API 변경사항

  ### 변경된 API 인증 방식
  ```diff
  # 설문조사 기본정보 저장
  - POST /api/v1/surveys/basic-info?userId=123
  + POST /api/v1/surveys/basic-info
  + Authorization: Bearer {JWT_TOKEN}

  # 소모임 생성
  - POST /api/v1/group?userId=123
  + POST /api/v1/group
  + Authorization: Bearer {JWT_TOKEN}

  # 채팅방 접근
  - GET /api/v1/chatrooms/accessible?userId=123
  + GET /api/v1/chatrooms/accessible
  + Authorization: Bearer {JWT_TOKEN}

  데이터 구조 변경

  # 설문조사/소모임 요청
  {
  -  "city": "SEOUL",
  +  "cityId": 1,
     "gender": "MALE"
  }

  데이터베이스 변경사항

  - 새 테이블: countries, cities
  - Country code 컬럼 길이 확장: VARCHAR(10) → VARCHAR(20)
  - 마이그레이션 스크립트: migration_country_city.sql

  보안 강화

  - 모든 주요 API에 JWT 인증 필수 적용
  - @AuthenticationPrincipal UserVo 사용으로 사용자 정보 자동 추출
  - Swagger UI에 JWT 토큰 입력 기능 추가

  참고 사항

  - 프론트엔드: 설문조사 시 도시 선택은 /api/v1/locations/cities/favorites 및
  /api/v1/locations/cities API 사용
  - JWT 토큰: 모든 API 호출 시 Authorization: Bearer {token} 헤더 필수
  - 마이그레이션: migration_country_city.sql 실행 후 기존 Country enum 데이터 이관 필요
  - Swagger: 우측 상단 "Authorize" 버튼으로 JWT 토큰 입력하여 API 테스트 가능