### PR TITLE
feat: 설문조사 조회 API 추가 및 소모임 상태 관리 개선

### DIFF
--- a/src/main/java/com/helpie/backend/controller/group/GroupController.java
+++ b/src/main/java/com/helpie/backend/controller/group/GroupController.java
@@ -39,7 +39,20 @@ public class GroupController {
     @PostMapping(value = "/create",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Secured(UserRole.USER_TYPE)
     @SecurityRequirement(name = "JWT Authentication")
-    @Operation(summary = "소모임 등록", description = "소모임을 등록합니다")
+    @Operation(summary = "소모임 등록", 
+               description = """
+                           새로운 소모임을 생성합니다.
+                           
+                           **주요 필드:**
+                           - cityId: 도시 ID (/api/v1/locations/cities에서 조회)
+                           - endAt: 모집 마감 날짜시간 (이후 RECRUITMENT_CLOSED 상태로 변경)
+                           - 생성 시 초기 상태: RECRUITING
+                           
+                           **상태 변화:**
+                           1. RECRUITING (모집중) - 생성 시 기본 상태
+                           2. RECRUITMENT_CLOSED (모집마감) - endAt 이후 또는 정원 달성 시
+                           3. COMPLETED (모임완료) - 방장이 수동으로 완료 처리
+                           """)
     public ResponseEntity<GroupCreateResponse> createGroup(
         @AuthenticationPrincipal UserVo userVo,
         @Parameter(description = "소모임 생성 정보 (cityId는 도시 ID)") @RequestPart("payload") GroupCreateRequest request,

--- a/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
+++ b/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
@@ -3,6 +3,7 @@ package com.helpie.backend.controller.survey;
 import com.helpie.backend.domain.user.UserRole;
 import com.helpie.backend.domain.user.UserVo;
 import com.helpie.backend.dto.survey.SurveyBasicInfoRequest;
+import com.helpie.backend.dto.survey.SurveyBasicInfoResponse;
 import com.helpie.backend.service.survey.SurveyBasicInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -111,5 +112,39 @@ public class SurveyBasicInfoController {
         
         log.info("설문조사 기본정보 수정 완료 - userId: {}", userVo.getId());
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 설문조사 기본정보를 조회합니다.
+     */
+    @GetMapping("/basic-info")
+    @Secured(UserRole.USER_TYPE)
+    @SecurityRequirement(name = "JWT Authentication")
+    @Operation(summary = "설문조사 기본정보 조회", 
+               description = """
+                           인증된 사용자의 설문조사 기본정보를 조회합니다.
+                           
+                           **응답 필드:**
+                           - cityId: 도시 ID
+                           - cityName: 도시명 (한국어)
+                           - gender: 성별 (MALE/FEMALE)
+                           - ageGroup: 연령대 (TEENS/TWENTIES/THIRTIES/FORTIES/FIFTIES_AND_ABOVE)
+                           - languages: 사용 언어 목록
+                           - interests: 관심사 목록
+                           """)
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "등록된 정보를 찾을 수 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<SurveyBasicInfoResponse> getSurveyBasicInfo(
+            @AuthenticationPrincipal UserVo userVo) {
+        
+        log.info("설문조사 기본정보 조회 요청 - userId: {}", userVo.getId());
+        
+        SurveyBasicInfoResponse response = surveyBasicInfoService.getSurveyBasicInfo(userVo.getId());
+        
+        log.info("설문조사 기본정보 조회 완료 - userId: {}", userVo.getId());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/helpie/backend/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupCreateRequest.java
@@ -16,8 +16,8 @@ import java.util.Set;
           "cityId": 1,
           "interests": ["MOVIE_WATCHING", "DISCUSSION"],
           "category": "CULTURAL",
-          "endAt": "2025-11-30T23:59:00+09:00"
-          "maxMember": 10
+          "maxMember": 10,
+          "endAt": "2025-11-30T23:59:00"
         }
         """)
 public record GroupCreateRequest(
@@ -32,7 +32,8 @@ public record GroupCreateRequest(
     Set<Interest> interests,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     Category category,
-    @Schema(requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "모집 마감 날짜 및 시간", 
+            example = "2025-11-30T23:59:00", requiredMode = RequiredMode.REQUIRED)
     LocalDateTime endAt,
     @Schema(requiredMode = RequiredMode.REQUIRED)
     Integer maxMember

--- a/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
@@ -2,7 +2,23 @@ package com.helpie.backend.dto.group;
 
 import com.helpie.backend.domain.group.Category;
 import com.helpie.backend.domain.group.Group;
+import com.helpie.backend.domain.group.GroupStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "소모임 응답 정보",
+        example = """
+        {
+          "title": "영화 감상 모임",
+          "description": "매주 영화를 보고 이야기 나누는 모임입니다",
+          "cityName": "서울",
+          "category": "CULTURAL",
+          "maxMember": 10,
+          "thumbnail": null,
+          "isPopular": false,
+          "dayBefore": 5,
+          "status": "RECRUITING"
+        }
+        """)
 public record GroupResponse(
     String title,
     String description,
@@ -11,7 +27,8 @@ public record GroupResponse(
     Integer maxMember,
     String thumbnail,
     Boolean isPopular,
-    Integer dayBefore
+    Integer dayBefore,
+    GroupStatus status
     ) {
     public static GroupResponse from(Group group) {
         return new GroupResponse(
@@ -22,7 +39,8 @@ public record GroupResponse(
             group.getMaxMembers(),
             null,
             group.isPopular(),
-            group.getDayBefore()
+            group.getDayBefore(),
+            group.getStatus()
         );
     }
 

--- a/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoResponse.java
+++ b/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoResponse.java
@@ -6,6 +6,7 @@ import com.helpie.backend.domain.survey.Gender;
 import com.helpie.backend.domain.survey.Interest;
 import com.helpie.backend.domain.survey.Language;
 import com.helpie.backend.domain.survey.SurveyBasicInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,21 @@ import java.util.Set;
  * @author 전우선
  * @since 2025-10-19(일)
  */
+@Schema(description = "설문조사 기본정보 응답",
+        example = """
+        {
+          "id": 1,
+          "userId": 123,
+          "cityName": "서울",
+          "cityId": 1,
+          "gender": "MALE",
+          "ageGroup": "TWENTIES",
+          "languages": ["KOREAN", "ENGLISH"],
+          "interests": ["MOVIE_WATCHING", "EXERCISE"],
+          "createdAt": "2025-11-05T10:30:00",
+          "updatedAt": "2025-11-05T10:30:00"
+        }
+        """)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/helpie/backend/repository/group/GroupRepository.java
+++ b/src/main/java/com/helpie/backend/repository/group/GroupRepository.java
@@ -36,7 +36,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     SELECT g FROM Group g
     WHERE g.city IN :cities
       AND (:category = 'ALL' OR g.category = :category)
-      AND g.status ='RECRUITING'
+      AND g.status IN ('RECRUITING', 'RECRUITMENT_CLOSED')
 """)
     Page<Group> findAllByFilters(@Param("cities") List<City> cities, @Param("category") Category category, Pageable pageable);
 
@@ -44,7 +44,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     @Query("""
     SELECT g FROM Group g
     WHERE g.city = :city
-      AND g.status ='RECRUITING'
+      AND g.status IN ('RECRUITING', 'RECRUITMENT_CLOSED')
        AND EXISTS (
            SELECT i FROM g.interests i
             WHERE i IN :interests

--- a/src/main/java/com/helpie/backend/service/chatroom/ChatRoomService.java
+++ b/src/main/java/com/helpie/backend/service/chatroom/ChatRoomService.java
@@ -28,6 +28,15 @@ public interface ChatRoomService {
     ChatRoomResponse enterChatRoom(Long chatRoomId, Long userId, String userName);
     
     /**
+     * 채팅방이 활성화 상태인지 확인합니다.
+     * 소모임 상태가 RECRUITING 또는 RECRUITMENT_CLOSED일 때만 채팅 가능
+     * 
+     * @param chatRoomId 채팅방 ID
+     * @return 채팅 가능 여부
+     */
+    boolean isChatEnabled(Long chatRoomId);
+    
+    /**
      * 채팅방에서 퇴장합니다. (자동 퇴장)
      * 
      * @param chatRoomId 채팅방 ID

--- a/src/main/java/com/helpie/backend/service/chatroom/ChatRoomServiceImpl.java
+++ b/src/main/java/com/helpie/backend/service/chatroom/ChatRoomServiceImpl.java
@@ -6,6 +6,7 @@ import com.helpie.backend.domain.chatroom.ChatMessage;
 import com.helpie.backend.domain.chatroom.MessageType;
 import com.helpie.backend.domain.group.Group;
 import com.helpie.backend.domain.group.GroupMember;
+import com.helpie.backend.domain.group.GroupStatus;
 import com.helpie.backend.dto.chatroom.ChatRoomResponse;
 import com.helpie.backend.dto.chatroom.ChatMessageResponse;
 import com.helpie.backend.dto.chatroom.SendMessageRequest;
@@ -230,6 +231,19 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         if (!groupMember.getIsActive()) {
             throw new ChatRoomAccessDeniedException();
         }
+    }
+    
+    @Override
+    public boolean isChatEnabled(Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+            .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다: " + chatRoomId));
+        
+        Group group = chatRoom.getGroup();
+        GroupStatus status = group.getStatus();
+        
+        // RECRUITING 또는 RECRUITMENT_CLOSED 상태일 때만 채팅 가능
+        // COMPLETED 상태가 되면 채팅 차단
+        return status == GroupStatus.RECRUITING || status == GroupStatus.RECRUITMENT_CLOSED;
     }
     
 }

--- a/src/main/java/com/helpie/backend/service/survey/SurveyBasicInfoService.java
+++ b/src/main/java/com/helpie/backend/service/survey/SurveyBasicInfoService.java
@@ -1,6 +1,7 @@
 package com.helpie.backend.service.survey;
 
 import com.helpie.backend.dto.survey.SurveyBasicInfoRequest;
+import com.helpie.backend.dto.survey.SurveyBasicInfoResponse;
 import com.helpie.backend.exception.survey.SurveyBasicInfoAlreadyExistsException;
 import com.helpie.backend.exception.survey.SurveyBasicInfoNotFoundException;
 
@@ -23,4 +24,10 @@ public interface SurveyBasicInfoService {
      * @throws SurveyBasicInfoNotFoundException 등록된 정보가 없는 경우
      */
     void updateSurveyBasicInfo(Long userId, SurveyBasicInfoRequest request);
+    
+    /**
+     * 설문조사 기본정보를 조회합니다.
+     * @throws SurveyBasicInfoNotFoundException 등록된 정보가 없는 경우
+     */
+    SurveyBasicInfoResponse getSurveyBasicInfo(Long userId);
 }

--- a/src/main/java/com/helpie/backend/service/survey/SurveyBasicInfoServiceImpl.java
+++ b/src/main/java/com/helpie/backend/service/survey/SurveyBasicInfoServiceImpl.java
@@ -3,6 +3,7 @@ package com.helpie.backend.service.survey;
 import com.helpie.backend.domain.location.City;
 import com.helpie.backend.domain.survey.SurveyBasicInfo;
 import com.helpie.backend.dto.survey.SurveyBasicInfoRequest;
+import com.helpie.backend.dto.survey.SurveyBasicInfoResponse;
 import com.helpie.backend.exception.survey.SurveyBasicInfoAlreadyExistsException;
 import com.helpie.backend.exception.survey.SurveyBasicInfoNotFoundException;
 import com.helpie.backend.repository.location.CityRepository;
@@ -46,6 +47,17 @@ public class SurveyBasicInfoServiceImpl implements SurveyBasicInfoService {
         updateSurveyBasicInfoData(surveyBasicInfo, request);
         
         log.info("설문조사 기본정보 수정 완료 - userId: {}", userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SurveyBasicInfoResponse getSurveyBasicInfo(Long userId) {
+        log.debug("설문조사 기본정보 조회 시작 - userId: {}", userId);
+        
+        SurveyBasicInfo surveyBasicInfo = findSurveyBasicInfoByUserId(userId);
+        
+        log.info("설문조사 기본정보 조회 완료 - userId: {}", userId);
+        return SurveyBasicInfoResponse.from(surveyBasicInfo);
     }
 
     /**


### PR DESCRIPTION
# 설문조사 기본정보 조회 API 및 GroupStatus 업데이트

  ## 작업 내용
  - [x] 설문조사 기본정보 조회 API (GET /api/v1/surveys/basic-info) 추가
  - [x] SurveyBasicInfoService에 getSurveyBasicInfo 메서드 구현
  - [x] GroupStatus 관련 로직 업데이트
  (RECRUITING/RECRUITMENT_CLOSED/COMPLETED)
  - [x] 채팅방 활성화 상태 확인 로직 추가 (isChatEnabled)
  - [x] Swagger 문서 개선 및 API 예시 JSON 추가
  - [x] GroupRepository 쿼리 GroupStatus 조건 수정

  ## 체크리스트
  - [x] 코드 작성 완료
  - [x] 문서/README 업데이트 (필요 시)
  - [x] 코드 스타일/컨벤션 확인

  ## 관련 이슈
  - 설문조사 조회 기능 요구사항
  - GroupStatus 변경에 따른 영향 코드 수정

  ## 참고 사항
  - **JWT 인증 필수**: 모든 새로운 API는 JWT 토큰 인증이 필요합니다
  - **GroupStatus 변경 사항**: 다른 팀원이 변경한 GroupStatus enum에 맞춰 모든 관련 로직을 업데이트했습니다
    - ACTIVE → RECRUITING
    - INACTIVE → RECRUITMENT_CLOSED
    - FULL → COMPLETED
  - **채팅방 정책**: COMPLETED 상태의 소모임은 채팅이 차단됩니다
  - **Swagger UI**: 새로운 조회 API가 Swagger 문서에 자동 반영됩니다
