### PR TITLE
feat: cityName 형식을 '국가명 > 도시명'으로 표준화

### DIFF
--- a/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
+++ b/src/main/java/com/helpie/backend/controller/survey/SurveyBasicInfoController.java
@@ -126,7 +126,7 @@ public class SurveyBasicInfoController {
                            
                            **응답 필드:**
                            - cityId: 도시 ID
-                           - cityName: 도시명 (한국어)
+                           - cityName: 도시명 (국가명 > 도시명 형식, 예: "대한민국 > 서울")
                            - gender: 성별 (MALE/FEMALE)
                            - ageGroup: 연령대 (TEENS/TWENTIES/THIRTIES/FORTIES/FIFTIES_AND_ABOVE)
                            - languages: 사용 언어 목록

--- a/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
         {
           "title": "영화 감상 모임",
           "description": "매주 영화를 보고 이야기 나누는 모임입니다",
-          "cityName": "서울",
+          "cityName": "대한민국 > 서울",
           "category": "CULTURAL",
           "maxMember": 10,
           "thumbnail": null,
@@ -34,7 +34,7 @@ public record GroupResponse(
         return new GroupResponse(
             group.getTitle(),
             group.getDescription(),
-            group.getCity().getName(),
+            group.getCity().getCountry().getName() + " > " + group.getCity().getName(),
             group.getCategory(),
             group.getMaxMembers(),
             null,

--- a/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoResponse.java
+++ b/src/main/java/com/helpie/backend/dto/survey/SurveyBasicInfoResponse.java
@@ -25,7 +25,7 @@ import java.util.Set;
         {
           "id": 1,
           "userId": 123,
-          "cityName": "서울",
+          "cityName": "대한민국 > 서울",
           "cityId": 1,
           "gender": "MALE",
           "ageGroup": "TWENTIES",
@@ -55,7 +55,7 @@ public class SurveyBasicInfoResponse {
         return new SurveyBasicInfoResponse(
                 surveyBasicInfo.getId(),
                 surveyBasicInfo.getUserId(),
-                surveyBasicInfo.getCity().getName(),
+                surveyBasicInfo.getCity().getCountry().getName() + " > " + surveyBasicInfo.getCity().getName(),
                 surveyBasicInfo.getCity().getId(),
                 surveyBasicInfo.getGender(),
                 surveyBasicInfo.getAgeGroup(),


### PR DESCRIPTION
# cityName 형식을 '국가명 > 도시명'으로 표준화

  ## 작업 내용
  - [x] SurveyBasicInfoResponse cityName 형식 변경 ("오사카" → "일본 > 오사카")
  - [x] GroupResponse cityName 형식 통일 ("서울" → "대한민국 > 서울")
  - [x] Swagger 문서 개선 및 cityName 형식 설명 추가

 ## 참고 사항
  - **cityName 형식 변경**: 모든 API에서 "국가명 > 도시명" 형태로 통일 (예:"일본 > 오사카")