### PR TITLE
feat: 소모임 실제 모임 날짜(meetingDate) 필드 추가

### DIFF
--- a/src/main/java/com/helpie/backend/controller/group/GroupController.java
+++ b/src/main/java/com/helpie/backend/controller/group/GroupController.java
@@ -46,6 +46,7 @@ public class GroupController {
                            **주요 필드:**
                            - cityId: 도시 ID (/api/v1/locations/cities에서 조회)
                            - endAt: 모집 마감 날짜시간 (이후 RECRUITMENT_CLOSED 상태로 변경)
+                           - meetingDate: 실제 모임이 열리는 날짜시간 (참여자들이 모이는 시간)
                            - 생성 시 초기 상태: RECRUITING
                            
                            **상태 변화:**

--- a/src/main/java/com/helpie/backend/domain/group/Group.java
+++ b/src/main/java/com/helpie/backend/domain/group/Group.java
@@ -77,6 +77,9 @@ public class Group {
     @Column(name="end_at",nullable = false)
     private LocalDateTime endAt;
 
+    @Column(name = "meeting_date", nullable = false)
+    private LocalDateTime meetingDate;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
@@ -88,7 +91,7 @@ public class Group {
 
     public Group(String title, String description, City city, Set<Interest> interests,
         Category category, Integer maxMembers, Integer currentMembers,
-        Long createdBy,LocalDateTime endAt) {
+        Long createdBy, LocalDateTime endAt, LocalDateTime meetingDate) {
         this.title = title;
         this.description = description;
         this.city = city;
@@ -99,14 +102,15 @@ public class Group {
         this.currentMembers = currentMembers != null ? currentMembers : 0;
         this.createdBy = createdBy;
         this.endAt = endAt;
+        this.meetingDate = meetingDate;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
     public Group(String title, String description, City city, Category category,
-        Set<Interest> interests, Integer maxMember,LocalDateTime endAt) {
+        Set<Interest> interests, Integer maxMember, LocalDateTime endAt, LocalDateTime meetingDate) {
         this(title, description, city, interests, category, maxMember, 0,
-            null,endAt);
+            null, endAt, meetingDate);
     }
 
     @PreUpdate
@@ -145,12 +149,12 @@ public class Group {
 
     public int getDayBefore(){
         LocalDate today = LocalDate.now();
-        LocalDate endDate = this.endAt.toLocalDate();
+        LocalDate meetingLocalDate = this.meetingDate.toLocalDate();
 
-        if (endDate.isBefore(today)) {
+        if (meetingLocalDate.isBefore(today)) {
             throw new RuntimeException("이미 완료된 소모임입니다.");
         }
 
-        return (int) ChronoUnit.DAYS.between(today, endDate);
+        return (int) ChronoUnit.DAYS.between(today, meetingLocalDate);
     }
 }

--- a/src/main/java/com/helpie/backend/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupCreateRequest.java
@@ -17,7 +17,8 @@ import java.util.Set;
           "interests": ["MOVIE_WATCHING", "DISCUSSION"],
           "category": "CULTURAL",
           "maxMember": 10,
-          "endAt": "2025-11-30T23:59:00"
+          "endAt": "2025-11-30T23:59:00",
+          "meetingDate": "2025-12-01T19:00:00"
         }
         """)
 public record GroupCreateRequest(
@@ -35,6 +36,9 @@ public record GroupCreateRequest(
     @Schema(description = "모집 마감 날짜 및 시간", 
             example = "2025-11-30T23:59:00", requiredMode = RequiredMode.REQUIRED)
     LocalDateTime endAt,
+    @Schema(description = "모임 예정 날짜 및 시간 (실제 모임이 열리는 날짜)", 
+            example = "2025-12-01T19:00:00", requiredMode = RequiredMode.REQUIRED)
+    LocalDateTime meetingDate,
     @Schema(requiredMode = RequiredMode.REQUIRED)
     Integer maxMember
 ) {

--- a/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
@@ -5,6 +5,8 @@ import com.helpie.backend.domain.group.Group;
 import com.helpie.backend.domain.group.GroupStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 @Schema(description = "소모임 응답 정보",
         example = """
         {
@@ -15,8 +17,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
           "maxMember": 10,
           "thumbnail": null,
           "isPopular": false,
-          "dayBefore": 5,
-          "status": "RECRUITING"
+          "dayBefore": 25,
+          "status": "RECRUITING",
+          "meetingDate": "2025-12-01T19:00:00"
         }
         """)
 public record GroupResponse(
@@ -28,7 +31,8 @@ public record GroupResponse(
     String thumbnail,
     Boolean isPopular,
     Integer dayBefore,
-    GroupStatus status
+    GroupStatus status,
+    LocalDateTime meetingDate
     ) {
     public static GroupResponse from(Group group) {
         return new GroupResponse(
@@ -40,7 +44,8 @@ public record GroupResponse(
             null,
             group.isPopular(),
             group.getDayBefore(),
-            group.getStatus()
+            group.getStatus(),
+            group.getMeetingDate()
         );
     }
 

--- a/src/main/java/com/helpie/backend/service/group/GroupService.java
+++ b/src/main/java/com/helpie/backend/service/group/GroupService.java
@@ -56,7 +56,8 @@ public class GroupService {
             req.category(),
             req.interests(),
             req.maxMember(),
-            req.endAt()
+            req.endAt(),
+            req.meetingDate()
             );
         Group savedGroup = groupRepository.save(group);
         log.info("소모임 생성 완료 - groupId: {}", savedGroup.getId());


### PR DESCRIPTION
 # 소모임 엔티티에 모임 예정 날짜(meetingDate) 필드 추가

  ## 작업 내용
  - [x] Group 엔티티에 meetingDate 필드 추가 (실제 모임 예정 날짜)
  - [x] GroupCreateRequest에 meetingDate 필드 추가 및 Swagger 예시 업데이트
  - [x] GroupResponse에 meetingDate 필드 추가 및 응답에 포함
  - [x] GroupService 소모임 생성 로직에 meetingDate 처리 추가
  - [x] getDayBefore 메서드를 endAt → meetingDate 기준으로 변경 (모임까지 남은 일수)
  - [x] GroupController Swagger 문서에 meetingDate 설명 추가
  - [x] 전체 빌드 테스트 및 컴파일 확인

  ## 체크리스트
  - [x] 코드 작성 완료
  - [x] 테스트 완료
  - [x] 문서/README 업데이트 (필요 시)
  - [x] 코드 스타일/컨벤션 확인

  ## 관련 이슈
  - 소모임 모집 마감일과 실제 모임 날짜 분리 요구사항

  ## 참고 사항
  - **모임 날짜 구분**: endAt(모집 마감) vs meetingDate(실제 모임) 분리하여 명확한 일정 관리
  - **dayBefore 로직 변경**: 모집 마감까지가 아닌 실제 모임까지 남은 일수로 변경
  - **JPA 자동 DDL**: 새로운 meeting_date 컬럼이 자동으로 생성됩니다
  - **프론트엔드 영향**: 소모임 생성 시 meetingDate 필드가 필수로 추가되어야 함
  - **날짜 검증 필요**: meetingDate는 endAt 이후여야 함 (모집 마감 후 모임 진행)
