### PR TITLE
feat: object storage 및 예시 파일 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,11 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.3'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.3'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.3'
-	
+
+	// bucket
+	implementation platform("software.amazon.awssdk:bom:2.26.22")
+	implementation "software.amazon.awssdk:s3"
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/helpie/backend/config/NCPStorageConfig.java
+++ b/src/main/java/com/helpie/backend/config/NCPStorageConfig.java
@@ -1,0 +1,40 @@
+package com.helpie.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
+
+@Configuration
+public class NCPStorageConfig {
+    @Value("${ncp.storage.region}")
+    private String region;
+
+    @Value("${ncp.storage.endpoint}")
+    private String endPoint; // https://kr.object.ncloudstorage.com
+
+    @Value("${ncp.storage.accessKey}")
+    private String accessKey;
+
+    @Value("${ncp.storage.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .endpointOverride(URI.create(endPoint))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true) // ★ NCP 호환용
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/helpie/backend/controller/file/FileTestController.java
+++ b/src/main/java/com/helpie/backend/controller/file/FileTestController.java
@@ -1,0 +1,85 @@
+package com.helpie.backend.controller.file;
+
+import com.helpie.backend.dto.global.Response;
+import com.helpie.backend.service.file.FileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/file")
+@RequiredArgsConstructor
+public class FileTestController {
+    private final FileService fileService;
+
+    @Operation(
+            summary = "단일 파일 업로드",
+            description = """
+            Multipart 단일 파일 업로드.
+            - 허용 타입: image/jpeg, image/png, image/gif, application/pdf
+            - 단일 파일 최대 10MB
+            업로드 후 접근 가능한 URL을 반환
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "업로드 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Response.class),
+                            examples = @ExampleObject(value = """
+                {
+                  "success": true,
+                  "data": "https://kr.object.ncloudstorage.com/helpie-bucket/uploads/2025/11/07/uuid.png"
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 파일/사이즈 초과/허용 타입 아님"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 또는 S3 업로드 실패")
+    })
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Response<String> upload(@RequestPart("file") MultipartFile file) {
+        return Response.success(fileService.uploadFile(file));
+    }
+
+    @Operation(
+            summary = "여러 파일 업로드",
+            description = """
+            Multipart 다중 파일 업로드.
+            - 같은 키(files)로 여러 개 첨부
+            - 파일당 최대 10MB, 요청 전체 30MB
+            업로드 후 각 파일 URL 리스트를 반환합니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "업로드 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                            examples = @ExampleObject(value = """
+                {
+                  "success": true,
+                  "data": [
+                    "https://kr.object.ncloudstorage.com/helpie-bucket/uploads/2025/11/07/uuid1.png",
+                    "https://kr.object.ncloudstorage.com/helpie-bucket/uploads/2025/11/07/uuid2.pdf"
+                  ]
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 파일/사이즈 초과/허용 타입 아님"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 또는 S3 업로드 실패")
+    })
+    @PostMapping(value = "/uploads", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Response<List<String>> uploadBatch(@RequestPart("files") List<MultipartFile> files) {
+        return Response.success(fileService.uploadFiles(files));
+    }
+}

--- a/src/main/java/com/helpie/backend/exception/ErrorCode.java
+++ b/src/main/java/com/helpie/backend/exception/ErrorCode.java
@@ -35,7 +35,23 @@ public enum ErrorCode {
     NOT_MATCH_SOCIAL_MEMBER(HttpStatus.UNAUTHORIZED, "SOCIAL_001", ""),
     NOT_MATCH_OAUTH_CODE(HttpStatus.UNAUTHORIZED, "SOCIAL_002", "인증 code가 존재하지 않습니다."),
     NOT_ALLOW_OAUTH_REDIRECT_URI(HttpStatus.BAD_REQUEST, "SOCIAL_003","승인되지 않은 redirectURI입니다."),
-    
+
+    // == 파일 업로드 도메인 에러 ==
+    FAILED_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "FILE_001", "파일 업로드에 실패했습니다."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE_002", "업로드할 파일이 존재하지 않습니다."),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "FILE_003", "파일명이 유효하지 않습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "FILE_004", "지원하지 않는 파일 형식입니다."),
+    FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "FILE_005", "업로드 가능한 파일 크기를 초과했습니다."),
+    FILE_STREAM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_006", "파일을 읽는 중 오류가 발생했습니다."),
+
+    // == S3/스토리지 에러 ==
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_001", "스토리지 업로드 중 오류가 발생했습니다."),
+    S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_002", "스토리지에서 파일 삭제 중 오류가 발생했습니다."),
+    S3_NO_SUCH_BUCKET(HttpStatus.NOT_FOUND, "S3_003", "지정한 버킷을 찾을 수 없습니다."),
+    S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S3_004", "S3 접근 권한이 없습니다."),
+    S3_REGION_MISMATCH(HttpStatus.BAD_REQUEST, "S3_005", "S3 리전 설정이 올바르지 않습니다."),
+    S3_NETWORK_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "S3_006", "스토리지 서버와의 통신에 실패했습니다."),
+
     // === Survey 도메인 에러 ===
     SURVEY_BASIC_INFO_ALREADY_EXISTS(HttpStatus.CONFLICT, "SURVEY_001", "이미 등록된 설문조사 기본정보입니다"),
     SURVEY_BASIC_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY_002", "설문조사 기본정보를 찾을 수 없습니다"),
@@ -49,7 +65,11 @@ public enum ErrorCode {
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "COMMON_001", "입력값 검증에 실패했습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_002", "서버 내부 오류가 발생했습니다"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_003", "인증되지 않은 사용자입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "접근 권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_004", "접근 권한이 없습니다."),
+    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_005", "데이터베이스 처리 중 오류가 발생했습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "COMMON_006", "외부 API 호출 중 오류가 발생했습니다."),
+    REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "COMMON_007", "요청 시간이 초과되었습니다."),
+    BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "COMMON_008", "외부 서버로부터 잘못된 응답을 받았습니다.");
     
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/helpie/backend/service/file/FileService.java
+++ b/src/main/java/com/helpie/backend/service/file/FileService.java
@@ -1,0 +1,115 @@
+package com.helpie.backend.service.file;
+
+import com.helpie.backend.exception.BusinessException;
+import com.helpie.backend.exception.ErrorCode; // 예: 커스텀 에러코드 enum
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectAclRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private static final String BUCKET_NAME = "helpie-bucket";// 개별 파일 최대 10MB
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024L;
+    private static final long MAX_TOTAL_SIZE = 30 * 1024 * 1024L;
+
+    private static final List<String> ALLOWED_TYPES = List.of(
+            "image/jpeg", "image/png", "image/gif", "application/pdf"
+    );
+    private final S3Client s3Client;
+
+    public String uploadFile(MultipartFile file) {
+        validateFile(file);
+        String key = buildKey(file.getOriginalFilename());
+        putObject(file, key);
+        setPublicReadAcl(key);
+        return publicUrlLike(key); // 필요 시 presigned URL로 대체 가능
+    }
+
+    public List<String> uploadFiles(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) throw new BusinessException(ErrorCode.FILE_NOT_FOUND){};
+
+        long total = files.stream().mapToLong(MultipartFile::getSize).sum();
+        if (total > MAX_TOTAL_SIZE) {
+            throw new BusinessException(ErrorCode.FILE_TOO_LARGE,
+                    Map.of("limit", "30MB", "total", (total / (1024*1024)) + "MB")){};
+        }
+
+        List<String> urls = new ArrayList<>();
+        for (MultipartFile f : files) {
+            validateFile(f);
+            String key = buildKey(f.getOriginalFilename());
+            putObject(f, key);
+            setPublicReadAcl(key);
+            urls.add(publicUrlLike(key));
+        }
+        return urls;
+    }
+
+    private void putObject(MultipartFile file, String key) {
+        try (InputStream is = file.getInputStream()) {
+            PutObjectRequest req = PutObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+            s3Client.putObject(req, RequestBody.fromInputStream(is, file.getSize()));
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.FILE_STREAM_ERROR){};
+        }
+    }
+
+    // 업로드 후 객체에 퍼블릭 읽기 ACL 부여
+    private void setPublicReadAcl(String key) {
+        try {
+            PutObjectAclRequest aclReq = PutObjectAclRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(key)
+                    .acl(ObjectCannedACL.PUBLIC_READ) // ★ 공개 읽기
+                    .build();
+            s3Client.putObjectAcl(aclReq);
+        } catch (S3Exception e) {
+            log.error("S3 setObjectAcl failed for key {}: code={}, msg={}", key,
+                    e.awsErrorDetails().errorCode(), e.getMessage(), e);
+            throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED,
+                    Map.of("stage", "putObjectAcl", "code", e.awsErrorDetails().errorCode(), "msg", e.getMessage())){};
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) throw new BusinessException(ErrorCode.FILE_NOT_FOUND){};
+        String type = Optional.ofNullable(file.getContentType()).orElse("");
+        if (!ALLOWED_TYPES.contains(type)) throw new BusinessException(ErrorCode.INVALID_FILE_TYPE){};
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.FILE_TOO_LARGE,
+                    Map.of("limit","10MB","file",file.getOriginalFilename())){};
+        }
+    }
+
+    private String buildKey(String originalName) {
+        String ext = (originalName != null && originalName.contains(".")) ?
+                originalName.substring(originalName.lastIndexOf(".")) : "";
+        LocalDate d = LocalDate.now();
+        String datePath = "%d/%02d/%02d".formatted(d.getYear(), d.getMonthValue(), d.getDayOfMonth());
+        return "uploads/" + datePath + "/" + UUID.randomUUID() + ext;
+    }
+
+    private String publicUrlLike(String key) {
+        return "https://kr.object.ncloudstorage.com/" + BUCKET_NAME + "/" + key;
+    }
+}


### PR DESCRIPTION
# PR 제목
ncloud object storage 파일 업로드 추가

## 작업 내용
- [ ] 단일 파일 업로드
- [ ] 여러 파일 업로드
- [ ] 파일 예시 api 추가

## 체크리스트
- [x] 코드 작성 완료
- [x] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [ ] 코드 스타일/컨벤션 확인

## 관련 이슈
- Closes #66 

## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용