### PR TITLE
feat: 북마크 조회 API에 썸네일 URL 필드 추가

### DIFF
--- a/src/main/java/com/helpie/backend/dto/mypage/response/MyBookmarkResponse.java
+++ b/src/main/java/com/helpie/backend/dto/mypage/response/MyBookmarkResponse.java
@@ -35,7 +35,10 @@ public record MyBookmarkResponse(
         LocalDateTime meetingDate,
 
         @Schema(description = "모임 생성일")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
+        String thumbnailUrl
 ) {
 
     public static MyBookmarkResponse from(Group group) {
@@ -48,7 +51,8 @@ public record MyBookmarkResponse(
                 group.getCity().getName(),
                 group.getCategory(),
                 group.getMeetingDate(),
-                group.getCreatedAt()
+                group.getCreatedAt(),
+                group.getThumbnail()
         );
     }
 }


### PR DESCRIPTION
# PR 제목
북마크 조회 API에 thumbnailUrl 필드 추가

## 작업 내용
- MyBookmarkResponse 레코드에 `thumbnailUrl` 필드 추가
- `MyBookmarkResponse.from(Group group)` 메서드에서 `group.getThumbnail()` 호출하여 thumbnailUrl 설정
- 북마크 정보 조회 API(`/api/v1/my-page/bookmark-info`) 응답에 thumbnailUrl 포함

## 체크리스트
- [x] 코드 작성 완료
- [x] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [x] 코드 스타일/컨벤션 확인

## 관련 이슈

## 참고 사항
- Group 엔티티의 썸네일을 활용하여 북마크 응답에 포함
- 북마크 자체에는 썸네일 필드가 없고, 소모임(Group)의 썸네일을 보여주는 구조
