### PR TITLE
fix: 끝난 모임 D-day 0으로 처리하도록 수정

### DIFF
--- a/src/main/java/com/helpie/backend/dto/mypage/response/MyBookmarkResponse.java
+++ b/src/main/java/com/helpie/backend/dto/mypage/response/MyBookmarkResponse.java
@@ -45,6 +45,13 @@ public record MyBookmarkResponse(
 ) {
 
     public static MyBookmarkResponse from(Group group) {
+        int dDay;
+        try {
+            dDay = group.getDayBefore();
+        } catch (Exception e) {
+            dDay = 0; // 끝난 모임은 0으로 처리
+        }
+        
         return new MyBookmarkResponse(
                 group.getId(),
                 group.getTitle(),
@@ -56,7 +63,7 @@ public record MyBookmarkResponse(
                 group.getMeetingDate(),
                 group.getCreatedAt(),
                 group.getThumbnail(),
-                group.getDayBefore()
+                dDay
         );
     }
 }


### PR DESCRIPTION
# PR 제목
북마크 조회 API에서 끝난 모임 D-day를 0으로 처리하도록 수정

## 작업 내용
- MyBookmarkResponse.from()에서 getDayBefore() 예외 처리 추가
- 끝난 모임의 D-day를 0으로 반환하도록 수정
- API 호출 시 과거 모임이 있어도 안전하게 조회 가능

## 체크리스트
- [x] 코드 작성 완료
- [x] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [x] 코드 스타일/컨벤션 확인

## 관련 이슈
- Closes #이슈번호

## 참고 사항
- 끝난 모임은 D-day 0으로 표시되며, 프론트에서 "마감된 모임" UI 표시 가능
- getDayBefore() 예외로 인한 API 오류 방지
