### PR TITLE
feat: 인증 미완료 계정 중복 가입 허용 및 닉네임 검증 규칙 개선

### DIFF
--- a/src/main/java/com/helpie/backend/domain/user/UserRegexp.java
+++ b/src/main/java/com/helpie/backend/domain/user/UserRegexp.java
@@ -1,5 +1,5 @@
 package com.helpie.backend.domain.user;
 
 public class UserRegexp {
-    public static final String USERNAME_REGEXP = "^[a-zA-Z_]{1,1}[a-zA-Z._0-9]{3,14}$";
+    public static final String USERNAME_REGEXP = "^[가-힣a-zA-Z0-9]{2,12}$";
 }

--- a/src/main/java/com/helpie/backend/dto/auth/SignUpRequest.java
+++ b/src/main/java/com/helpie/backend/dto/auth/SignUpRequest.java
@@ -1,12 +1,27 @@
 package com.helpie.backend.dto.auth;
 
+import com.helpie.backend.domain.user.UserRegexp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
 
 public record SignUpRequest(
+        @NotNull
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String email,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        @Schema(
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                description = "유저 별명",
+                minLength = 2,
+                maxLength = 12,
+                pattern = UserRegexp.USERNAME_REGEXP
+        )
+        @Pattern(regexp = UserRegexp.USERNAME_REGEXP)
+        @Length(min = 2, max = 12)
         String username,
+        @NotNull
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String password
 ) {

--- a/src/main/java/com/helpie/backend/dto/sociallogin/SignupByCodeRequest.java
+++ b/src/main/java/com/helpie/backend/dto/sociallogin/SignupByCodeRequest.java
@@ -14,12 +14,12 @@ public record SignupByCodeRequest(
         @Schema(
                 requiredMode = Schema.RequiredMode.REQUIRED,
                 description = "유저 별명",
-                minLength = 4,
-                maxLength = 15,
+                minLength = 2,
+                maxLength = 12,
                 pattern = UserRegexp.USERNAME_REGEXP
         )
         @Pattern(regexp = UserRegexp.USERNAME_REGEXP)
-        @Length(min = 4, max = 15)
+        @Length(min = 2, max = 12)
         String username,
 
         @NotNull

--- a/src/main/java/com/helpie/backend/repository/auth/EmailAuthRepository.java
+++ b/src/main/java/com/helpie/backend/repository/auth/EmailAuthRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long>, EmailAuthCustomRepository {
     Boolean existsByEmailAndAuthType(String email, AuthType authType);
     EmailAuth findByEmailAndAuthType(String email, AuthType authType);
+    Boolean existsByEmailAndAuthTypeAndExpired(String email, AuthType authType, Boolean expired);
+    void deleteByEmailAndAuthType(String email, AuthType authType);
 }

--- a/src/main/java/com/helpie/backend/service/user/UserService.java
+++ b/src/main/java/com/helpie/backend/service/user/UserService.java
@@ -65,7 +65,18 @@ public class UserService {
         if (this.existsByUsername(username)) {
             throw new BusinessException(ErrorCode.ALREADY_EXIST_MEMBER, "이미 존재하는 유저입니다.") {
             };
+        }
 
+        if (this.existsByEmail(email)) {
+            // 이메일 인증이 완료되지 않은 계정인지 확인
+            if (!this.isEmailVerified(email)) {
+                // 미인증 계정 삭제
+                this.deleteUnverifiedUser(email);
+            } else {
+                // 인증 완료된 계정이면 중복 오류
+                throw new BusinessException(ErrorCode.ALREADY_EXIST_MEMBER, "이미 존재하는 이메일 입니다.") {
+                };
+            }
         }
 
         final var user = new User(username, email, password);
@@ -100,6 +111,35 @@ public class UserService {
     @Transactional(readOnly = true)
     public Boolean existsByEmail(String email) {
         return this.userRepository.existsByEmail(email);
+    }
+
+    /**
+     * 이메일 인증이 완료되었는지 확인
+     */
+    @Transactional(readOnly = true)
+    public boolean isEmailVerified(String email) {
+        // EMAIL_AUTH 타입으로 인증이 완료된(expired=true) 기록이 있는지 확인
+        return emailAuthRepository.existsByEmailAndAuthTypeAndExpired(
+                email, 
+                com.helpie.backend.domain.email.AuthType.EMAIL_AUTH, 
+                true
+        );
+    }
+
+    /**
+     * 미인증 계정 삭제
+     */
+    @Transactional
+    public void deleteUnverifiedUser(String email) {
+        userRepository.findByEmail(email).ifPresent(user -> {
+            // 관련된 EmailAuth 기록도 삭제
+            emailAuthRepository.deleteByEmailAndAuthType(
+                    email, 
+                    com.helpie.backend.domain.email.AuthType.EMAIL_AUTH
+            );
+            // 사용자 삭제
+            userRepository.delete(user);
+        });
     }
 }
 


### PR DESCRIPTION
# PR 제목
미인증 계정 재가입 허용 및 닉네임 검증 규칙 개선

## 작업 내용
- [x] 인증 미완료(PENDING) 계정 재가입 허용 로직 구현
  - 기존 미인증 계정 삭제 후 새로 생성
  - 인증 완료 계정은 중복 가입 차단
- [x] 닉네임 검증 정규식 개선
  - 한글 및 일반적인 닉네임 입력 가능하도록 수정
- [ ] 관련 단위 테스트 작성 및 검증

## 체크리스트
- [x] 코드 작성 완료
- [x] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [x] 코드 스타일/컨벤션 확인

## 관련 이슈
- Closes #이슈번호

## 참고 사항
- 기존 User 엔티티는 수정하지 않고 EmailAuth 기반으로 인증 상태 확인 후 처리
