### PR TITLE
refactor: pagination에서 fetch join 시 메모리에 모두 로드되는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//RestDocs
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/helpie/backend/controller/group/GroupController.java
+++ b/src/main/java/com/helpie/backend/controller/group/GroupController.java
@@ -96,10 +96,7 @@ public class GroupController {
         @Valid @ModelAttribute CursorRequest request
 
     ){
-        if (request.getCountry().equals("ALL")){
-            return ResponseEntity.ok(groupService.getAllGroups(userVo.getId(),request));
-        }
-        return ResponseEntity.ok(groupService.getGroupsByCountry(userVo.getId(),request));
+        return ResponseEntity.ok(groupService.getGroups(userVo.getId(),request));
     }
 
     @PostMapping("/mark/{groupId}")

--- a/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
+++ b/src/main/java/com/helpie/backend/dto/group/GroupResponse.java
@@ -46,6 +46,7 @@ public class GroupResponse {
     private GroupStatus status;
     private LocalDateTime meetingDate;
     private Boolean isMarked;
+    private LocalDateTime createdAt;
     private static final String DEFAULT_THUMBNAIL_URL="https://kr.object.ncloudstorage.com/helpie-bucket/uploads/2025/11/10/62d39fbe-b94c-4b79-a606-84e80754f9fc.png";
 
     public static GroupResponse from(Group group) {

--- a/src/main/java/com/helpie/backend/repository/group/GroupCustomRepository.java
+++ b/src/main/java/com/helpie/backend/repository/group/GroupCustomRepository.java
@@ -1,11 +1,10 @@
 package com.helpie.backend.repository.group;
 
-import com.helpie.backend.domain.group.Category;
-import com.helpie.backend.domain.group.Group;
 import com.helpie.backend.domain.location.City;
+import com.helpie.backend.dto.group.CursorRequest;
+import com.helpie.backend.dto.group.GroupResponse;
 import com.helpie.backend.dto.group.MyGroupResponse;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,5 +13,7 @@ public interface GroupCustomRepository {
 
     Page<MyGroupResponse> findMyGroups(Long userId, String status, Pageable pageable);
 
-    List<Group> findPage(List<City> cities, Category category, LocalDateTime cursorCreatedAt, Long cursorId, int size);
+    List<Long> findPageIds(List<City> cities, CursorRequest request);
+
+    List<GroupResponse> findGroupsWithImagesByIds(List<Long> ids,Long userId);
 }

--- a/src/main/java/com/helpie/backend/repository/group/impl/GroupCustomRepositoryImpl.java
+++ b/src/main/java/com/helpie/backend/repository/group/impl/GroupCustomRepositoryImpl.java
@@ -3,13 +3,21 @@ package com.helpie.backend.repository.group.impl;
 import com.helpie.backend.domain.group.Category;
 import com.helpie.backend.domain.group.Group;
 import com.helpie.backend.domain.group.GroupStatus;
+import com.helpie.backend.domain.group.QBookmark;
 import com.helpie.backend.domain.group.QGroup;
+import com.helpie.backend.domain.group.QGroupImage;
 import com.helpie.backend.domain.group.QGroupMember;
 import com.helpie.backend.domain.location.City;
+import com.helpie.backend.dto.group.CursorRequest;
+import com.helpie.backend.dto.group.GroupResponse;
 import com.helpie.backend.dto.group.MyGroupResponse;
 import com.helpie.backend.repository.group.GroupCustomRepository;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +38,8 @@ public class GroupCustomRepositoryImpl implements GroupCustomRepository {
     private final JPAQueryFactory queryFactory;
     private final QGroup groupQ = QGroup.group;
     private final QGroupMember groupMemberQ = QGroupMember.groupMember;
+    private final QGroupImage img = QGroupImage.groupImage;
+    private final QBookmark bookmark = QBookmark.bookmark;
 
     @Override
     public Page<MyGroupResponse> findMyGroups(Long userId, String status, Pageable pageable) {
@@ -117,19 +127,61 @@ public class GroupCustomRepositoryImpl implements GroupCustomRepository {
         return new PageImpl<>(content, pageable, total != null ? total : 0);
     }
 
-    public List<Group> findPage(List<City> cities, Category category, LocalDateTime cursorCreatedAt, Long cursorId, int size) {
-
+    public List<Long> findPageIds(List<City> cities, CursorRequest request) {
         return queryFactory
-            .selectFrom(groupQ)
-            .leftJoin(groupQ.images).fetchJoin()
+            .select(groupQ.id)
+            .from(groupQ)
             .where(
-                filterGroups(groupQ,cities,category),
-                cursorCondition(groupQ,cursorCreatedAt,cursorId)
+                filterGroups(groupQ, cities, request.getCategory()),
+                cursorCondition(groupQ, request.getCursorCreatedAt(), request.getCursorId())
             )
             .orderBy(groupQ.createdAt.desc(), groupQ.id.desc())
-            .limit(size)
+            .limit(request.getSize()+1)
             .fetch();
     }
+
+    public List<GroupResponse> findGroupsWithImagesByIds(List<Long> groupIds,Long userId) {
+        return queryFactory
+            .select(Projections.constructor(
+                        GroupResponse.class,
+                        groupQ.id,
+                        groupQ.title,
+                        groupQ.description,
+                        groupQ.city.name,
+                        groupQ.category,
+                        groupQ.maxMembers,
+                        getFirstImage(),
+                        Expressions.constant(false),
+                        Expressions.constant(3),
+                        groupQ.status,
+                        groupQ.meetingDate,
+                        getBookmarkYn(userId),
+                        groupQ.createdAt))
+            .from(groupQ)
+            .where(groupQ.id.in(groupIds))
+            .orderBy(groupQ.createdAt.desc(), groupQ.id.desc())
+            .fetch();
+    }
+
+    private Expression<Boolean> getBookmarkYn(Long userId) {
+        return JPAExpressions
+            .select(bookmark.bookmarkYn)
+            .from(bookmark)
+            .where(bookmark.groupId.eq(groupQ.id)
+                .and(bookmark.userId.eq(userId)))
+            .exists();
+    }
+
+
+    private Expression<String> getFirstImage() {
+        return JPAExpressions
+            .select(img.imageUrl)
+            .from(img)
+            .where(img.group.id.eq(groupQ.id))
+            .orderBy(img.id.asc())
+            .limit(1);
+    }
+
 
     private BooleanExpression filterGroups(QGroup g, List<City> cities, Category category) {
         return g.city.in(cities)

--- a/src/main/java/com/helpie/backend/repository/group/impl/GroupCustomRepositoryImpl.java
+++ b/src/main/java/com/helpie/backend/repository/group/impl/GroupCustomRepositoryImpl.java
@@ -20,6 +20,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -177,9 +178,15 @@ public class GroupCustomRepositoryImpl implements GroupCustomRepository {
         return JPAExpressions
             .select(img.imageUrl)
             .from(img)
-            .where(img.group.id.eq(groupQ.id))
-            .orderBy(img.id.asc())
-            .limit(1);
+            .where(
+                img.id.eq(
+                    JPAExpressions
+                        .select(img.id.min())
+                        .from(img)
+                        .where(img.group.id.eq(groupQ.id))
+                )
+            );
+
     }
 
 

--- a/src/main/java/com/helpie/backend/service/group/GroupService.java
+++ b/src/main/java/com/helpie/backend/service/group/GroupService.java
@@ -122,50 +122,34 @@ public class GroupService {
         return GroupResponse.from(group);
     }
 
-    public CursorResponse<GroupResponse> getAllGroups(Long userId,CursorRequest request) {
-        List<Group> fetched=groupRepository.findPage(cityRepository.findAll(), request.getCategory(), request.getCursorCreatedAt(), request.getCursorId(), request.getSize() + 1);
-        boolean hasNext = fetched.size() > request.getSize();
-        List<Group> page = hasNext ? fetched.subList(0, request.getSize()) : fetched;
+    public CursorResponse<GroupResponse> getGroups(Long userId,CursorRequest request) {
+        List<City> cities= validateCountry(request.getCountry());
+        List<Long> fetchedIds = groupRepository.findPageIds(cities,request);
 
-        List<GroupResponse> content = mapGroupsWithBookmarksV2(userId, page);
+        boolean hasNext = fetchedIds.size() > request.getSize();
+        List<Long> pageIds = hasNext ? fetchedIds.subList(0, request.getSize()) : fetchedIds;
+        List<GroupResponse> content=groupRepository.findGroupsWithImagesByIds(pageIds,userId);
 
-        CursorResponse.NextCursor nextCursor = null;
-        if (hasNext && !page.isEmpty()) {
-            Group last = page.get(page.size() - 1);
-            nextCursor = new CursorResponse.NextCursor(
-                last.getCreatedAt(),
-                last.getId()
-            );
+        if (!hasNext){
+            return new CursorResponse<>(content, hasNext, null);
         }
+
+        GroupResponse last = content.get(content.size() - 1);
+        CursorResponse.NextCursor  nextCursor = new CursorResponse.NextCursor(last.getCreatedAt(), last.getId());
 
         return new CursorResponse<>(content, hasNext, nextCursor);
     }
 
-    public CursorResponse<GroupResponse> getGroupsByCountry(Long userId,CursorRequest request) {
-        Country country = countryRepository.findByCode(request.getCountry())
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 국가 코드입니다."));
-
-        List<City> cities = cityRepository.findAllByCountry(country);
-
-        List<Group> fetched = groupRepository.findPage(
-            cities, request.getCategory(), request.getCursorCreatedAt(), request.getCursorId(), request.getSize() + 1
-        );
-
-        boolean hasNext = fetched.size() > request.getSize();
-        List<Group> page = hasNext ? fetched.subList(0, request.getSize()) : fetched;
-
-        List<GroupResponse> content = mapGroupsWithBookmarksV2(userId, page);
-
-        CursorResponse.NextCursor nextCursor = null;
-        if (hasNext && !page.isEmpty()) {
-            Group last = page.get(page.size() - 1);
-            nextCursor = new CursorResponse.NextCursor(
-                last.getCreatedAt(),
-                last.getId()
-            );
+    private List<City> validateCountry(String countryCode) {
+        if (countryCode.equals("ALL")){
+            return cityRepository.findAll();
         }
 
-        return new CursorResponse<>(content, hasNext, nextCursor);
+        Country country = countryRepository.findByCode(countryCode)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 국가 코드입니다."));
+
+        return cityRepository.findAllByCountry(country);
+
     }
 
     /**
@@ -208,26 +192,6 @@ public class GroupService {
      */
     public Page<MyGroupResponse> getMyGroups(Long userId, String status, Pageable pageable) {
         return groupRepository.findMyGroups(userId, status, pageable);
-    }
-
-    private List<GroupResponse> mapGroupsWithBookmarksV2(Long userId, List<Group> groups) {
-        if (groups.isEmpty()) {
-            return List.of();
-        }
-
-        List<Long> groupIds = groups.stream()
-            .map(Group::getId)
-            .toList();
-
-        Set<Long> bookmarkedIds = bookmarkRepository
-            .findAllByUserIdAndGroupIdIn(userId, groupIds)
-            .stream()
-            .map(Bookmark::getGroupId)
-            .collect(Collectors.toUnmodifiableSet());
-
-        return groups.stream()
-            .map(group -> GroupResponse.from(group, bookmarkedIds.contains(group.getId())))
-            .toList();
     }
 
     private Page<GroupResponse> mapGroupsWithBookmarks(Long userId, Page<Group> groups) {

--- a/src/test/java/com/helpie/backend/common/builder/BuilderSupporter.java
+++ b/src/test/java/com/helpie/backend/common/builder/BuilderSupporter.java
@@ -1,5 +1,6 @@
 package com.helpie.backend.common.builder;
 
+import com.helpie.backend.repository.group.GroupImageRepository;
 import com.helpie.backend.repository.group.GroupRepository;
 import com.helpie.backend.repository.location.CityRepository;
 import com.helpie.backend.repository.location.CountryRepository;
@@ -18,6 +19,9 @@ public class BuilderSupporter {
     @Autowired
     private CountryRepository countryRepository;
 
+    @Autowired
+    private GroupImageRepository groupImageRepository;
+
     public CityRepository cityRepository() {
         return cityRepository;
     }
@@ -28,6 +32,10 @@ public class BuilderSupporter {
 
     public CountryRepository countryRepository() {
         return countryRepository;
+    }
+
+    public GroupImageRepository groupImageRepository() {
+        return groupImageRepository;
     }
 
 }

--- a/src/test/java/com/helpie/backend/common/builder/TestFixtureBuilder.java
+++ b/src/test/java/com/helpie/backend/common/builder/TestFixtureBuilder.java
@@ -4,6 +4,7 @@ import com.helpie.backend.common.fixtures.CityFixtures;
 import com.helpie.backend.common.fixtures.CountryFixtures;
 import com.helpie.backend.domain.group.Category;
 import com.helpie.backend.domain.group.Group;
+import com.helpie.backend.domain.group.GroupImage;
 import com.helpie.backend.domain.location.City;
 import com.helpie.backend.domain.location.Country;
 import com.helpie.backend.repository.location.CityRepository;
@@ -48,6 +49,12 @@ public class TestFixtureBuilder {
         return repository.findByCode(CountryFixtures.CODE)
             .orElseGet(() -> repository.save(CountryFixtures.COUNTRY()));
 
+    }
+
+    public GroupImage buildGroupImage(Group group,String imageUrl){
+        GroupImage image=new GroupImage(group,imageUrl);
+
+        return bs.groupImageRepository().save(image);
     }
 
 }

--- a/src/test/java/com/helpie/backend/group/CursorRepositoryTest.java
+++ b/src/test/java/com/helpie/backend/group/CursorRepositoryTest.java
@@ -4,10 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.helpie.backend.common.builder.BuilderSupporter;
 import com.helpie.backend.common.builder.TestFixtureBuilder;
+import com.helpie.backend.common.fixtures.AuthFixtures;
 import com.helpie.backend.common.fixtures.GroupFixtures;
+
 import com.helpie.backend.config.QueryDslConfig;
-import com.helpie.backend.domain.group.Category;
 import com.helpie.backend.domain.group.Group;
+
+import com.helpie.backend.domain.location.City;
+import com.helpie.backend.dto.group.CursorRequest;
+import com.helpie.backend.dto.group.GroupResponse;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -29,29 +33,23 @@ public class CursorRepositoryTest {
     @Autowired
     BuilderSupporter builderSupporter;
 
-
     @Test
     @DisplayName("첫 페이지에서 커서 파라미터를 전달하지 않는다")
     void createdAt_no_param() {
-
         Group g1 = builder.buildGroup(GroupFixtures.FIRST_CREATED_AT);
         Group g2 = builder.buildGroup(GroupFixtures.SECOND_CREATED_AT);
         Group g3 = builder.buildGroup(GroupFixtures.THIRD_CREATED_AT);
+        City cities=builder.buildCity();
+        CursorRequest request=GroupFixtures.cursorRequest(null,null,1);
+        List<Long> ret=builderSupporter.groupRepository().findPageIds(List.of(cities),request);
+        List<GroupResponse> result=builderSupporter.groupRepository().findGroupsWithImagesByIds(ret, AuthFixtures.user().getId());
 
-        List<Group> result = builderSupporter.groupRepository().findPage(
-            List.of(builder.buildCity()),
-            Category.HOBBY,
-            null,
-            null,2
-        );
-
-        assertThat(result).extracting(Group::getId)
+        assertThat(result).extracting(GroupResponse::getId)
             .containsExactly(
                 g3.getId(),
                 g2.getId()
             );
     }
-
 
     @Test
     @DisplayName("createdAt 내림차순으로 반환한다")
@@ -59,20 +57,20 @@ public class CursorRepositoryTest {
         Group g1 = builder.buildGroup(GroupFixtures.FIRST_CREATED_AT);
         Group g2 = builder.buildGroup(GroupFixtures.SECOND_CREATED_AT);
         Group g3 = builder.buildGroup(GroupFixtures.THIRD_CREATED_AT);
-
+        City cities=builder.buildCity();
         Long cursorId = g1.getId();
+        int size=3;
 
-        List<Group> result = builderSupporter.groupRepository().findPage(
-            List.of(builder.buildCity()),
-            Category.HOBBY,
-            GroupFixtures.CURSOR_CREATED_AT,
-            cursorId,2
-        );
+        CursorRequest request=GroupFixtures.cursorRequest(cursorId,GroupFixtures.CURSOR_CREATED_AT,size);
 
-        assertThat(result).extracting(Group::getId)
+        List<Long> ret=builderSupporter.groupRepository().findPageIds(List.of(cities),request);
+        List<GroupResponse> result=builderSupporter.groupRepository().findGroupsWithImagesByIds(ret, AuthFixtures.user().getId());
+
+        assertThat(result).extracting(GroupResponse::getId)
             .containsExactly(
                 g3.getId(),
-                g2.getId()
+                g2.getId(),
+                g1.getId()
             );
     }
 
@@ -80,24 +78,19 @@ public class CursorRepositoryTest {
     @Test
     @DisplayName("createdAt이 동일할 때 id를 내림차순으로 반환한다")
     void same_createdAt_id_desc() {
+        int size = 5;
+        City cities=builder.buildCity();
+        CursorRequest request=GroupFixtures.cursorRequest(null,null,size);
+
         Group g1 = builder.buildGroup(GroupFixtures.FIRST_CREATED_AT);
         Group g2 =builder.buildGroup(GroupFixtures.FIRST_CREATED_AT);
         Group g3 =builder.buildGroup(GroupFixtures.FIRST_CREATED_AT);
         Group g4 = builder.buildGroup(GroupFixtures.FIRST_CREATED_AT);
 
+        List<Long> ret=builderSupporter.groupRepository().findPageIds(List.of(cities),request);
+        List<GroupResponse> result=builderSupporter.groupRepository().findGroupsWithImagesByIds(ret, AuthFixtures.user().getId());
 
-        Long cursorId = g3.getId();
-
-        List<Group> result = builderSupporter.groupRepository().findPage(
-            List.of(builder.buildCity()),
-            Category.HOBBY,
-            GroupFixtures.CURSOR_CREATED_AT,
-            cursorId,
-            5
-
-        );
-
-        assertThat(result).extracting(Group::getId)
+        assertThat(result).extracting(GroupResponse::getId)
             .containsExactly(
                 g4.getId(),
                 g3.getId(),

--- a/src/test/java/com/helpie/backend/group/GroupServiceTest.java
+++ b/src/test/java/com/helpie/backend/group/GroupServiceTest.java
@@ -51,7 +51,7 @@ class GroupServiceTest {
         int size = groups.size() - 1;
 
         CursorRequest request = GroupFixtures.cursorRequest(null, null, size);
-        var firstResponse = groupService.getGroupsByCountry(
+        var firstResponse = groupService.getGroups(
             AuthFixtures.user().getId(),
             request
         );
@@ -62,7 +62,7 @@ class GroupServiceTest {
         var nextCreatedAt = firstResponse.nextCursor().createdAt();
 
         CursorRequest nextRequest = GroupFixtures.cursorRequest(nextCursorId, nextCreatedAt, size);
-        var secondResponse = groupService.getGroupsByCountry(
+        var secondResponse = groupService.getGroups(
             AuthFixtures.user().getId(),
             nextRequest
         );
@@ -80,12 +80,14 @@ class GroupServiceTest {
     void last_page_hasNext_false() {
         // given
         Integer size = groups.size();
-        Long cursorId = groups.get(0).getId();
-        LocalDateTime createdAt = groups.get(0).getCreatedAt();
+        Group last=groups.get(size-1);
+        Long cursorId = last.getId();
+        LocalDateTime createdAt = last.getCreatedAt();
+        Long userId= AuthFixtures.user().getId();
 
         CursorRequest request = GroupFixtures.cursorRequest(cursorId, createdAt, size);
-        var response = groupService.getGroupsByCountry(
-            AuthFixtures.user().getId(),
+        var response = groupService.getGroups(
+            userId,
             request
         );
 
@@ -93,6 +95,5 @@ class GroupServiceTest {
         assertThat(response.hasNext()).isFalse();
 
     }
-
 
 }

--- a/src/test/java/com/helpie/backend/group/respository/CursorRepositoryTest.java
+++ b/src/test/java/com/helpie/backend/group/respository/CursorRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.helpie.backend.group;
+package com.helpie.backend.group.respository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/helpie/backend/group/respository/ImageRepositoryTest.java
+++ b/src/test/java/com/helpie/backend/group/respository/ImageRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.helpie.backend.group.respository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.helpie.backend.common.builder.BuilderSupporter;
+import com.helpie.backend.common.builder.TestFixtureBuilder;
+import com.helpie.backend.common.fixtures.AuthFixtures;
+import com.helpie.backend.common.fixtures.GroupFixtures;
+import com.helpie.backend.config.QueryDslConfig;
+import com.helpie.backend.domain.group.Group;
+import com.helpie.backend.domain.group.GroupImage;
+import com.helpie.backend.dto.group.GroupResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(value= {TestFixtureBuilder.class, BuilderSupporter.class, QueryDslConfig.class})
+public class ImageRepositoryTest {
+
+    @Autowired
+    TestFixtureBuilder builder;
+
+    @Autowired
+    BuilderSupporter builderSupporter;
+
+    private final Long userId=AuthFixtures.user().getId();
+    private List<Group> groups = new ArrayList<>();
+
+
+    @BeforeEach
+    void setUp() {
+        groups.add(builder.buildGroup(GroupFixtures.FIRST_CREATED_AT));
+    }
+
+    @Test
+    @DisplayName("이미지가 여러 장 존재하면 가장 id가 작은 값을 반환한다")
+    void multi_image_return_minimum_id(){
+        int groupIdx=0;
+        Group group = groups.get(groupIdx);
+        GroupImage img1=builder.buildGroupImage(group,"test1");
+        GroupImage img2=builder.buildGroupImage(group,"test2");
+
+        List<GroupResponse> result=builderSupporter.groupRepository().findGroupsWithImagesByIds(List.of(group.getId()), userId);
+
+        assertThat(result.get(groupIdx).getThumbnail()).isEqualTo(img1.getImageUrl());
+
+    }
+
+    @Test
+    @DisplayName("이미지가 존재하지 않으면 null을 반환한다")
+    void no_image_return_null(){
+        int groupIdx=0;
+        Group group = groups.get(groupIdx);
+
+        List<GroupResponse> result=builderSupporter.groupRepository().findGroupsWithImagesByIds(List.of(group.getId()), userId);
+
+        assertThat(result.get(groupIdx).getThumbnail()).isNull();
+    }
+
+
+}


### PR DESCRIPTION
# PR 제목
pagination+ fetch join을 함께 쓰면 아래와 같은 warn 로그가 발생합니다
<img width="1466" height="35" alt="스크린샷 2026-01-06 오전 10 44 12" src="https://github.com/user-attachments/assets/5d4275e1-310a-4137-9026-89d8ac45134a" />

## 작업 내용
- [x] fetch join을 제거
- [ ] 두 개의 엔티티를 조회하는 쿼리를 분리하여 N+1 방지

## 체크리스트
- [x] 코드 작성 완료
- [x] 테스트 완료
- [ ] 문서/README 업데이트 (필요 시)
- [x] 코드 스타일/컨벤션 확인

## 관련 이슈
- Closes #이슈번호

## 참고 사항
- 추가 설명이나 참고 링크
- 팀원에게 알리고 싶은 내용